### PR TITLE
RCA engine correctness: attribution audit (7 classes) + readiness fixes

### DIFF
--- a/RCA_ENGINE_AUDIT.md
+++ b/RCA_ENGINE_AUDIT.md
@@ -1,0 +1,118 @@
+# xtop RCA Engine — Correctness Audit
+
+**Method:** the RCA engine is a pure function `model.Snapshot → AnalysisResult`. Every finding below was located in code, given a concrete triggering metric scenario, and **adversarially verified** (a second agent tried to refute it by tracing the real matcher/branch with the scenario numbers). 27 confirmed, 2 rejected as unreachable/pre-empted.
+
+**Headline:** the bugs collapse into **7 structural classes**. The dominant one — *a specific-cause narrative firing without its defining evidence* — appears **~9 times** across CPU, memory, IO, network, and VM. Fixing the class fixes them all. That is why prior one-off patches never made it stick.
+
+Matcher semantics (verified, for reference): `MatchPattern` iterates patterns by **descending Priority**; first match wins and its narrative overrides templates. A pattern matches iff no `Required:true` evidence is missing **and** `count(fired conditions) ≥ MinMatch`. "Fired" = `normalize(value,warn,crit) > 0`.
+
+---
+
+## Class 1 — Specific narrative fires without its defining evidence  *(systemic, ~9 instances)*
+
+The pattern names a specific cause but `MinMatch` is low enough (or the defining condition isn't `Required`) that a **generic, high-base-rate** signal (PSI, latency, busy) alone satisfies it. Result: confident, specific, **wrong** WHY.
+
+| Sev | File:line | Bug |
+|---|---|---|
+| **CRIT** | `engine/patterns.go:55` | `Memory-Induced IO Storm` (P90) defining ID **`mem.swap.activity` is never emitted anywhere**. With MinMatch:1 it fires "swap thrashing" on *pure disk IO*, and at P90 it **hijacks essentially every IO-latency incident**. (Found independently by 3 lanes.) |
+| **CRIT** | `engine/patterns.go:59` | Same phantom `mem.swap.activity` — "memory pressure spilling to swap → IO" narrative with no swap signal. |
+| **HIGH** | `engine/patterns.go` `VM Noisy Neighbor` | **SEED-A** — MinMatch:1 over {`cpu.steal`(≥0.1), `cpu.psi`} → `cpu.psi` alone prints "hypervisor stealing CPU time" at 1.1% steal. |
+| **HIGH** | `engine/patterns.go:343` | `VM CPU Throttle` MinMatch:1 → `pve.vm.cpupsi` alone claims "hitting cgroup CPU limit" with `throttle=0`. (2 lanes.) |
+| **HIGH** | `engine/patterns.go:187` | `Network Congestion` (P60) asserts "retransmits" without requiring `net.tcp.retrans`; masks the correct conntrack narrative. |
+| **HIGH** | `engine/narrative.go:26` | Template "…cascading to IO via swap" (P90) fires from `mem.psi`+`io.disk.latency` with **no swap evidence**. |
+| **MED** | `engine/patterns.go:354` | `pve.vm.memlimit` narrative without the limit signal firing. |
+| **MED** | `engine/patterns.go:108` | `Disk IO Saturation` claims "processes in D-state" without `io.dstate` firing. |
+| **LOW** | `engine/patterns.go:105` | Same D-state clause, second site. |
+
+**Structural fix:** mark each pattern's *defining* evidence `Required:true` (the technique already used correctly by `CPU Throttle Cascade`), and **either emit `mem.swap.activity` or delete the patterns that depend on it.** One matcher-discipline pass + one evidence fix removes the whole class.
+
+---
+
+## Class 2 — Bonus/score applied without the gating signal firing
+
+| Sev | File:line | Bug |
+|---|---|---|
+| **HIGH** | `engine/rca_cpu.go:232` | Steal bonus (+10) gated only on generic `v2TrustGate` and applied **before** ScoreFloor → 6% steal can resurrect/flip the CPU domain even when steal evidence didn't fire. |
+| **HIGH** | `engine/rca_memory.go:114` | Reclaim PSI-dampening lowers **confidence**, but the matcher keys off **strength** → `Direct Reclaim Storm` still fires with PSI=0. |
+| **MED** | `engine/rca_network.go:511` | drops/softirq bonus added without either underlying signal firing. |
+| **LOW** | `ui/app.go:2219` | `pinnedResolvedSec` computed but never read. |
+
+**Structural fix:** gate every bonus on the *specific* evidence's strength, and apply bonuses relative to the score floor, not before it.
+
+---
+
+## Class 3 — Normalize/unit bugs (evidence always-fires or is dead)
+
+| Sev | File:line | Bug |
+|---|---|---|
+| **HIGH** | `engine/rca_io.go:112` | `io.writeback` warn/crit thresholds (5/20) are in the wrong unit vs the byte-valued metric → **strength pinned at 1.0 on every host**. Permanent false "writeback pressure". |
+| **HIGH** | `engine/rca_io.go:141` | fs-full dampener compares **FREE%** against `95` when it means **USED%** → dampener is dead code; any static 85–95%-full mount hijacks the narrative at 0.9 confidence. |
+
+**Structural fix:** add a unit assertion/test per evidence: feed a known-quiet snapshot, assert strength 0; feed a known-critical one, assert 1.0.
+
+---
+
+## Class 4 — WHO contradicts WHY (blame ≠ narrative)
+
+The most user-visible tell (WHO=`sentinel` while WHY=hypervisor on your screen).
+
+| Sev | File:line | Bug |
+|---|---|---|
+| **HIGH** | `engine/rca_io.go:257` | IO culprit uses bare `SwapInRate>0 \|\| DirectReclaimRate>0` → blames an idle top-RSS process over the real writer. |
+| **HIGH** | `engine/blame.go:163` | `blameMemory` has no slab-aware branch → a **kernel slab leak** is blamed on an innocent userspace top-RSS process. |
+| **HIGH** | `ui/app.go:2057` | Sticky pin re-pins only on strictly-higher score → a *different* current cause is masked by the pinned one. |
+| **MED** | `engine/blame.go:150` | CPU steal→hypervisor blame uses a different entry threshold than the narrative, so they diverge in a band. |
+| **MED** | `ui/overview_header.go:48` | Header shows pinned health while the body is live. |
+
+**Structural fix:** a single post-classification invariant — *if WHY names an external/kernel/hypervisor cause, WHO must not be a local userspace PID (and vice-versa)* — enforced in one place, with a test.
+
+---
+
+## Class 5 — Confidence decoupled from evidence *(explains the on-screen 93%)*
+
+| Sev | File:line | Bug |
+|---|---|---|
+| **HIGH** | `engine/scoring.go:100` | `domainConfidence` ignores signal **strength** and the **selected narrative** → a weak, misattributed cause is still displayed at 93%+. This is why the wrong narrative looked authoritative. |
+
+**Structural fix:** confidence must be a function of the fired evidence strength backing the *chosen* narrative, not the domain score alone.
+
+---
+
+## Class 6 — Live data rendered next to pinned/stale RCA  *(SEED Bug B family)*
+
+| Sev | File:line | Bug |
+|---|---|---|
+| **MED** | `ui/overview_blocks.go:1832` | Pinned owners shown against live IO. |
+| **MED** | `ui/overview_blocks.go:713` | Pinned capacities vs live subsystem capacity (the 30.9%-vs-93% split). |
+| **LOW** | `engine/adaptive_threshold.go:155` | Adaptive thresholds with no observations silently pinned to base (looks tuned, isn't). |
+
+**Structural fix:** render a snapshot atomically — either freeze the whole panel set with the pinned result, or clearly label pinned sections "(held Xs)". Never mix in one frame.
+
+---
+
+## Class 7 — Priority ordering / wrong source
+
+| Sev | File:line | Bug |
+|---|---|---|
+| **HIGH** | `engine/patterns.go:91` | `CPU Oversubscription` (P78) has no steal-exclusion, so it can pre-empt genuine steal/noisy-neighbor patterns (P65/58) in the reverse scenario. |
+| **HIGH** | `engine/rca_cpu.go` | **SEED-B** — run-queue derived from `Load1/nCPUs` not instantaneous `procs_running` → real saturation never fires, disqualifying the correct pattern. |
+| **MED** | `engine/patterns.go:208` | conntrack-exhaustion pattern reads the wrong drop source. |
+
+---
+
+## Rejected by adversarial verification (2)
+
+Two candidate findings were traced and found **unreachable/pre-empted** — not reported as bugs. (Kept out deliberately; the point of the verify pass is to not cry wolf.)
+
+---
+
+## Systemic recommendations (fix classes, not screenshots)
+
+1. **Matcher discipline pass** — every specific-cause pattern marks its defining evidence `Required:true`; audit every `MinMatch`. Kills Class 1 (~9 bugs).
+2. **Emit-or-remove `mem.swap.activity`** — the single phantom evidence ID behind both CRITICALs.
+3. **Evidence unit tests** — quiet-snapshot→strength 0, critical-snapshot→1.0, for every evidence ID. Kills Class 3, prevents regressions.
+4. **WHO/WHY invariant** — one post-classification consistency check. Kills Class 4.
+5. **Confidence from chosen-narrative strength.** Kills Class 5.
+6. **Atomic frame rendering** (live vs pinned never mixed). Kills Class 6.
+7. **Golden-scenario test suite** — table of real `Snapshot`s (incl. your xgen1 capture) → asserted RCA. This is the regression net that makes it stay fixed across servers.
+</content>

--- a/RCA_PRODUCTION_READINESS_REVIEW.md
+++ b/RCA_PRODUCTION_READINESS_REVIEW.md
@@ -1,0 +1,247 @@
+# xtop RCA Production Readiness Review
+
+Date: 2026-07-12
+
+## Verdict
+
+The RCA engine is not fully production-ready for "all server types" or "all production issue types."
+
+It is a substantial Linux host RCA system with useful coverage for CPU, memory, IO, network, some app metrics, journal signatures, config drift, narratives, actions, history, and runbooks. But it is not a complete causal diagnosis engine. Several features are advisory, post-verdict, or only partially wired into the final RCA decision.
+
+Standard verification:
+
+- `go vet ./...` passed.
+- `go test ./...` passed outside the sandbox.
+- The first sandboxed `go test ./...` run failed only because the sandbox blocked Unix socket options and writes under `/root/.xtop`.
+
+No code was changed for this review.
+
+## Resolution Status — branch `fix/rca-attribution` (2026-07-12)
+
+All findings below have been addressed on this branch (TDD, one commit each; full suite 928 green):
+
+| # | Status | Commit / note |
+|---|---|---|
+| #1 Proxmox evidence after scoring | ✅ Fixed | pve.vm.* evidence now emitted before scoring |
+| #2 Config drift mutates score after finalization | ✅ Fixed | `correlateConfigDrift` + change detection moved into `AnalyzeRCA` before verifier/finalize via `e.detectChanges`; narrative hint kept in `Tick`. **Residual (follow-up):** a boosted non-primary domain does not re-select `PrimaryBottleneck` — ordering is fixed, primary re-selection is out of scope. |
+| #3 Journal Tier-1 post-verdict | ✅ Fixed | `injectJournalTier1` moved before the verifier loop (monotonic — can only strengthen a tier) |
+| #4 Verifier additive, not authoritative | ✅ Addressed (additive + label) | `AnalysisResult.PrimaryVerified`; RCA box labels `(unverified)` when the verifier didn't confirm a degraded/critical verdict |
+| #5 Fact/evidence ID mismatch | ✅ Fixed | duration stamping falls back to the `.avg10`-stripped base ID for PSI |
+| #6 Lean-mode reduced coverage | ✅ Fixed | `AnalysisResult.Coverage {Mode, OmittedSignals}` surfaces the reduced signal set |
+| #7 Duplicated OOM score-floor | ✅ Fixed | dead duplicate removed |
+
+## Key Findings
+
+### 1. Proxmox memory evidence is appended after scoring
+
+Severity: High
+
+In `engine/rca_memory.go`, memory scoring, evidence group counting, and checks conversion finish before Proxmox VM memory evidence is appended.
+
+Relevant code:
+
+- `engine/rca_memory.go:261` starts v2 scoring.
+- `engine/rca_memory.go:284` sets `EvidenceGroups`.
+- `engine/rca_memory.go:285` sets `Checks`.
+- `engine/rca_memory.go:400` starts appending Proxmox VM memory evidence.
+
+Impact:
+
+Proxmox VM OOM, swap, memory-limit, and VM memory PSI evidence can appear in `EvidenceV2` but cannot affect `Score`, `EvidenceGroups`, `Checks`, health, or primary RCA for that tick.
+
+This directly undermines production readiness for Proxmox hosts.
+
+Recommended fix:
+
+Move Proxmox VM memory evidence before scoring, then include it in `Facts` where appropriate. Add a regression test proving a VM OOM/memory-pressure scenario affects memory score and health.
+
+### 2. Config drift mutates score after health finalization
+
+Severity: High
+
+`AnalyzeRCA` finalizes health inside `engine/rca.go`, then `Engine.Tick` later calls `correlateConfigDrift`.
+
+Relevant code:
+
+- `engine/rca.go:405` runs finalization.
+- `engine/engine.go:614` calls `correlateConfigDrift`.
+- `engine/configdrift_evidence.go:275` boosts `entry.Score`.
+- `engine/configdrift_evidence.go:281` updates `PrimaryScore`.
+
+Impact:
+
+Config drift can change `PrimaryScore` after health, confidence, verifier output, causal DAG, actions, and much of the narrative have already been computed. This can produce score/verdict inconsistencies.
+
+Recommended fix:
+
+Feed config-drift evidence into the RCA pipeline before finalization, or rerun the finalization/verifier/narrative stages after score mutation. Prefer the first option so the pipeline remains single-pass and deterministic.
+
+### 3. Journal Tier-1 RCA is post-verdict evidence
+
+Severity: High
+
+Journal findings are injected near the end of `AnalyzeRCA`, after verification and health decisions.
+
+Relevant code:
+
+- `engine/rca.go:374` computes `VerifiedCauses`.
+- `engine/rca.go:405` finalizes health.
+- `engine/rca.go:620` calls `injectJournalTier1`.
+- `engine/journal_tier1.go:228` converts journal findings to facts.
+- `engine/journal_tier1.go:231` appends journal facts to `result.Facts`.
+
+Impact:
+
+Journal RCA is useful UI/context evidence, but it does not strengthen the verified cause or change the core RCA verdict in the same tick.
+
+Recommended fix:
+
+Make journal Tier-1 evidence available before verification/finalization, or explicitly document and label it as post-verdict supporting context.
+
+### 4. The formal verifier is additive, not authoritative
+
+Severity: High
+
+The engine computes `VerifiedCauses`, but health is still decided by raw score plus `v2TrustGate`.
+
+Relevant code:
+
+- `engine/rca.go:374` computes verifier output.
+- `engine/finalize.go:90` decides health by score bands and `v2TrustGate`.
+
+Impact:
+
+The UI or fleet payload can report degraded/critical RCA even when the formal verifier abstains. That is not "fully verified RCA."
+
+Recommended fix:
+
+Decide product semantics:
+
+- If the engine claims verified RCA, `VerifiedCauses` must gate the final claim.
+- If the engine is heuristic RCA plus optional verification, the UI/API should label unverified results clearly.
+
+### 5. Fact/evidence ID mismatches weaken temporal verification
+
+Severity: Medium-High
+
+Duration stamping joins facts to evidence strictly by ID.
+
+Relevant code:
+
+- `engine/fact_builders.go:124` builds the evidence-ID to sustained-duration map.
+- `engine/fact_builders.go:133` stamps duration only when fact ID matches evidence ID.
+- `engine/rca_cpu.go:82` emits evidence ID `cpu.psi`.
+- `engine/rca_cpu.go:113` emits fact ID `cpu.psi.avg10`.
+- `engine/rca_memory.go:130` emits evidence ID `mem.psi`.
+- `engine/rca_memory.go:161` emits fact ID `mem.psi.avg10`.
+
+Impact:
+
+PSI facts often miss sustained-duration data. That weakens the temporal-ordering verifier gate on core pressure signals.
+
+Recommended fix:
+
+Unify evidence and fact IDs or maintain an explicit mapping table. Add tests that sustained PSI evidence stamps matching fact durations.
+
+### 6. Fleet/lean mode intentionally has reduced RCA coverage
+
+Severity: Medium
+
+Lean mode omits several collectors.
+
+Relevant code:
+
+- `collector/collector.go:77` documents lean mode exclusions.
+- `collector/collector.go:135` defines lean collectors.
+
+Omitted in lean mode:
+
+- logs
+- sockets
+- softirq
+- sysctl
+- security
+- diag
+- Proxmox
+- GPU
+- deleted-open
+- fileless
+- bigfile
+
+Impact:
+
+Fleet agents cannot claim full RCA coverage. They run with a reduced signal set by design.
+
+Recommended fix:
+
+Make this explicit in product/docs/API output. Consider a "coverage" or "signal availability" field so fleet users know which RCA classes were observable.
+
+### 7. Memory scoring has duplicated OOM score-floor logic
+
+Severity: Low-Medium
+
+Relevant code:
+
+- `engine/rca_memory.go:266` sets `r.Score = int(v2Score)`.
+- `engine/rca_memory.go:268` applies OOM floor.
+- `engine/rca_memory.go:271` resets `r.Score = int(v2Score)`.
+- `engine/rca_memory.go:272` applies OOM floor again.
+
+Impact:
+
+Current behavior is mostly preserved because the OOM floor block is duplicated too, but the code is fragile and indicates patch-layer drift.
+
+Recommended fix:
+
+Remove the duplicate assignment/block and add a targeted OOM score-floor regression test.
+
+## Coverage Assessment
+
+Implemented reasonably well:
+
+- CPU contention
+- memory pressure
+- IO starvation
+- network overload
+- PSI-based detection
+- cgroup/process attribution
+- OOM deltas
+- disk latency/utilization
+- TCP retrans/drop/conntrack issues
+- some BPF sentinel signals
+- app-specific hints for common databases/web stacks
+- journal signature classification
+- config-drift detection
+- narratives/actions/history/runbooks
+
+Not fully implemented:
+
+- authoritative verified RCA
+- all app failure modes
+- all server roles
+- full service/entity graph
+- complete dependency causality
+- full Kubernetes/container RCA
+- full Proxmox production-grade RCA
+- fleet dashboard journal propagation
+- strong cloud/hypervisor-specific RCA
+- service/business impact RCA
+- root-cause proof for issues where host metrics look normal
+
+## Production Readiness Assessment
+
+For an operator-facing Linux troubleshooting TUI, this is useful and has meaningful diagnostics.
+
+For an automated claim of "fully correct RCA for all production servers and all incident types," it is not ready.
+
+The biggest architectural issue is pipeline ordering. Evidence should be collected and normalized before scoring, verification, finalization, causal DAG construction, actions, and narrative generation. Today, some important evidence arrives after those stages.
+
+## Priority Fix Plan
+
+1. Move all evidence emission before scoring/finalization.
+2. Make config drift and journal Tier-1 evidence first-class verifier inputs or clearly mark them as post-verdict context.
+3. Decide whether `VerifiedCauses` gates final RCA claims.
+4. Fix fact/evidence ID mismatches.
+5. Move Proxmox memory evidence before memory scoring.
+6. Add RCA coverage metadata for lean/fleet mode.
+7. Add golden scenario tests for Proxmox OOM, config drift near incident onset, journal crash loop, CPU PSI duration stamping, and lean-mode reduced-signal behavior.

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -103,6 +103,28 @@ func NewRegistryMode(mode Mode) *Registry {
 	return &Registry{collectors: richCollectors()}
 }
 
+// OmittedSignals returns the collector names present in rich mode but excluded
+// from the given mode's collector set (nil for rich). Computed as rich−lean so
+// it never drifts from the actual registries. Lets fleet/API consumers know
+// which RCA signal classes were not observable for a given tick.
+func OmittedSignals(mode Mode) []string {
+	if mode != ModeLean {
+		return nil
+	}
+	lean := make(map[string]bool)
+	for _, c := range leanCollectors() {
+		lean[c.Name()] = true
+	}
+	var omitted []string
+	for _, c := range richCollectors() {
+		if !lean[c.Name()] {
+			omitted = append(omitted, c.Name())
+		}
+	}
+	sort.Strings(omitted)
+	return omitted
+}
+
 func richCollectors() []Collector {
 	return []Collector{
 		&SysInfoCollector{},

--- a/collector/coverage_test.go
+++ b/collector/coverage_test.go
@@ -1,0 +1,29 @@
+//go:build linux
+
+package collector
+
+import "testing"
+
+// TestOmittedSignals covers readiness-review Finding #6: lean/fleet mode omits
+// several collectors, and consumers need to know which signal classes were not
+// observable. OmittedSignals reports the rich-minus-lean collector set.
+func TestOmittedSignals(t *testing.T) {
+	if got := OmittedSignals(ModeRich); len(got) != 0 {
+		t.Fatalf("rich mode omits nothing, got %v", got)
+	}
+
+	lean := OmittedSignals(ModeLean)
+	if len(lean) == 0 {
+		t.Fatal("lean mode should report omitted signal classes")
+	}
+	// bigfiles is one of the collectors excluded from lean mode.
+	found := false
+	for _, s := range lean {
+		if s == "bigfiles" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected 'bigfiles' among omitted lean signals, got %v", lean)
+	}
+}

--- a/engine/blame.go
+++ b/engine/blame.go
@@ -19,7 +19,7 @@ func ComputeBlame(result *model.AnalysisResult, curr *model.Snapshot, rates *mod
 	case BottleneckCPU:
 		entries = blameCPU(result, rates)
 	case BottleneckMemory:
-		entries = blameMemory(rates)
+		entries = blameMemory(result, rates)
 	case BottleneckIO:
 		entries = blameIO(result, rates)
 	case BottleneckNetwork:
@@ -146,8 +146,11 @@ func blameCPU(result *model.AnalysisResult, rates *model.RateSnapshot) []model.B
 		})
 	}
 
-	// If steal is the dominant issue, blame hypervisor
-	if rates.CPUStealPct > rates.CPUBusyPct*0.3 && rates.CPUStealPct > 5 {
+	// If steal is active, blame the hypervisor. Gate on the SAME signal the
+	// narrative uses (cpu.steal evidence active) rather than an ad-hoc
+	// steal>busy*0.3 threshold — otherwise WHO and WHY diverge in the band where
+	// the steal evidence fired but steal% stayed under busy%*0.3.
+	if stealActive {
 		entries = append([]model.BlameEntry{{
 			Comm: "hypervisor-steal",
 			Metrics: map[string]string{
@@ -160,7 +163,7 @@ func blameCPU(result *model.AnalysisResult, rates *model.RateSnapshot) []model.B
 	return entries
 }
 
-func blameMemory(rates *model.RateSnapshot) []model.BlameEntry {
+func blameMemory(result *model.AnalysisResult, rates *model.RateSnapshot) []model.BlameEntry {
 	type agg struct {
 		comm   string
 		pid    int
@@ -211,6 +214,19 @@ func blameMemory(rates *model.RateSnapshot) []model.BlameEntry {
 			Metrics:    metrics,
 			ImpactPct:  p.memPct,
 		})
+	}
+
+	// Kernel slab leak: the memory is unreclaimable kernel slab, not any
+	// userspace process. Prepend a kernel-slab entry so WHO agrees with the
+	// "kernel slab leak" narrative instead of blaming an innocent top-RSS process.
+	if hasActiveEvidence(result, BottleneckMemory, "mem.slab.leak") {
+		entries = append([]model.BlameEntry{{
+			Comm: "kernel-slab",
+			Metrics: map[string]string{
+				"slab": "unreclaimable kernel memory",
+			},
+			ImpactPct: 100,
+		}}, entries...)
 	}
 	return entries
 }

--- a/engine/configdrift_evidence.go
+++ b/engine/configdrift_evidence.go
@@ -286,15 +286,18 @@ func correlateConfigDrift(result *model.AnalysisResult, changes []model.SystemCh
 			driftFacts := InjectConfigDriftEvidence(nil, []model.SystemChange{rd.ch}, now)
 			result.Facts = append(result.Facts, driftFacts...)
 
-			// Surface a suggested (never applied) remediation in the narrative
-			// when this drift is the primary or a contributing bottleneck.
-			if result.Narrative != nil {
-				key, oldVal, newVal := parseDetailParts(rd.ch.Detail)
-				if hint := suggestedRemediation(key, oldVal, newVal); hint != "" {
-					result.Narrative.Evidence = append(
-						result.Narrative.Evidence,
-						"SUGGESTED: "+hint,
-					)
+			// Surface a suggested (never applied) remediation when this drift is
+			// the primary or a contributing bottleneck. correlateConfigDrift runs
+			// BEFORE the narrative is built (readiness #2), so stash it on the
+			// result; AnalyzeRCA injects it into Narrative.Evidence after
+			// BuildNarrative. Also append directly when a Narrative already exists
+			// (isolated-correlation callers/tests that build it up front).
+			key, oldVal, newVal := parseDetailParts(rd.ch.Detail)
+			if hint := suggestedRemediation(key, oldVal, newVal); hint != "" {
+				line := "SUGGESTED: " + hint
+				result.ConfigDriftSuggestions = append(result.ConfigDriftSuggestions, line)
+				if result.Narrative != nil {
+					result.Narrative.Evidence = append(result.Narrative.Evidence, line)
 				}
 			}
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -866,6 +866,16 @@ func (e *Engine) Tick() (*model.Snapshot, *model.RateSnapshot, *model.AnalysisRe
 		)
 	}
 
+	// Stamp signal coverage so consumers know whether this was a full or
+	// reduced-signal (lean/fleet) analysis.
+	if result != nil {
+		mode := "full"
+		if e.mode == collector.ModeLean {
+			mode = "lean"
+		}
+		result.Coverage = model.CoverageInfo{Mode: mode, OmittedSignals: collector.OmittedSignals(e.mode)}
+	}
+
 	return snap, rates, result
 }
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -556,63 +556,15 @@ func (e *Engine) Tick() (*model.Snapshot, *model.RateSnapshot, *model.AnalysisRe
 		peers := e.GetPeerIncidents()
 		result = AnalyzeRCA(snap, rates, e.History, peers, e)
 
-		// Change detection: track new/stopped processes and recent package changes
-		if e.changeDetector != nil {
-			result.Changes = e.changeDetector.DetectChanges(snap)
-		}
-		// Config drift: walk the watchlist of /etc/* configs; merge any newly-
-		// detected modifications into Changes so they appear in Recent Activity.
-		if e.configDrift != nil {
-			result.Changes = append(result.Changes, e.configDrift.Tick()...)
-
-			// If an incident is active, look back 30 minutes for config drift
-			// events. A config change that landed shortly before degradation
-			// is the single highest-yield piece of RCA context we can surface.
-			if result != nil && result.Health > model.HealthOK {
-				recent := e.configDrift.RecentWithin(time.Now(), 30*time.Minute)
-				if len(recent) > 0 && result.Narrative != nil {
-					hint := formatConfigDriftHint(recent)
-					if hint != "" {
-						result.Narrative.Evidence = append(
-							[]string{hint},
-							result.Narrative.Evidence...,
-						)
-					}
+		// Config-drift narrative hint (presentation only — reads finalized
+		// Health). Detection + score correlation already ran inside AnalyzeRCA.
+		if e.configDrift != nil && result != nil && result.Health > model.HealthOK && result.Narrative != nil {
+			recent := e.configDrift.RecentWithin(time.Now(), 30*time.Minute)
+			if len(recent) > 0 {
+				if hint := formatConfigDriftHint(recent); hint != "" {
+					result.Narrative.Evidence = append([]string{hint}, result.Narrative.Evidence...)
 				}
 			}
-		}
-
-		// P4.5 — kernel-parameter drift (sysctl / /proc/sys).
-		// Runs every 30 ticks (~30 s at 1 Hz). Best-effort: panics are
-		// recovered so a bad Snapshot() never aborts the tick.
-		e.tickCount++
-		if e.configDriftEnabled && e.paramDriftDetector != nil && e.tickCount%30 == 0 {
-			func() {
-				defer func() { recover() }() //nolint:errcheck
-				live, err := e.configSnapshotFn()
-				if err != nil || len(live) == 0 {
-					return
-				}
-				now := time.Now()
-				changes, newBaselines := e.paramDriftDetector.Detect(live, now)
-				if len(newBaselines) > 0 {
-					// Stage for the next SaveBaselineState flush.
-					e.pendingParamBaselines = append(e.pendingParamBaselines, newBaselines...)
-				}
-				if len(changes) > 0 && result != nil {
-					result.Changes = append(result.Changes, changes...)
-				}
-			}()
-		}
-
-		// Phase 4.4 — config-drift onset correlation: if any config_drift_*
-		// changes are recent (within driftCorrelationWindow) and share a
-		// domain with the active bottleneck, boost that candidate's score
-		// and attach the drift as a typed Fact. Runs after result.Changes
-		// is fully populated so both file-level and param-level drift are
-		// considered.
-		if result != nil {
-			correlateConfigDrift(result, result.Changes, time.Now())
 		}
 
 		// Confidence calibration: detect incident completions to record outcomes,

--- a/engine/engine_changes.go
+++ b/engine/engine_changes.go
@@ -1,0 +1,52 @@
+//go:build linux
+
+package engine
+
+import (
+	"time"
+
+	"github.com/ftahirops/xtop/model"
+)
+
+// detectChanges runs change detection, config-drift, and kernel-parameter
+// drift detection for this tick, returning the merged change list. This is
+// extracted (copied verbatim) from the detection logic inline in Tick; Tick
+// itself is left untouched for now.
+func (e *Engine) detectChanges(snap *model.Snapshot) []model.SystemChange {
+	var changes []model.SystemChange
+
+	// Change detection: track new/stopped processes and recent package changes
+	if e.changeDetector != nil {
+		changes = e.changeDetector.DetectChanges(snap)
+	}
+	// Config drift: walk the watchlist of /etc/* configs; merge any newly-
+	// detected modifications into Changes so they appear in Recent Activity.
+	if e.configDrift != nil {
+		changes = append(changes, e.configDrift.Tick()...)
+	}
+
+	// P4.5 — kernel-parameter drift (sysctl / /proc/sys).
+	// Runs every 30 ticks (~30 s at 1 Hz). Best-effort: panics are
+	// recovered so a bad Snapshot() never aborts the tick.
+	e.tickCount++
+	if e.configDriftEnabled && e.paramDriftDetector != nil && e.tickCount%30 == 0 {
+		func() {
+			defer func() { recover() }() //nolint:errcheck
+			live, err := e.configSnapshotFn()
+			if err != nil || len(live) == 0 {
+				return
+			}
+			now := time.Now()
+			paramChanges, newBaselines := e.paramDriftDetector.Detect(live, now)
+			if len(newBaselines) > 0 {
+				// Stage for the next SaveBaselineState flush.
+				e.pendingParamBaselines = append(e.pendingParamBaselines, newBaselines...)
+			}
+			if len(paramChanges) > 0 {
+				changes = append(changes, paramChanges...)
+			}
+		}()
+	}
+
+	return changes
+}

--- a/engine/entitygraph.go
+++ b/engine/entitygraph.go
@@ -31,6 +31,13 @@ func domainNameFromBottleneck(b string) string {
 	return string(domainFromBottleneck(b))
 }
 
+// isVerifiedTier reports whether a verification tier counts as "verified" for
+// labeling purposes: Tier A (confirmed) and B (verified) are trusted; Tier C
+// (probable) and D (inconclusive/abstain) are not, and should be labeled.
+func isVerifiedTier(t model.VerificationTier) bool {
+	return t == model.TierAConfirmed || t == model.TierBVerified
+}
+
 // factIDsForDomain returns the IDs of every Fact in the given domain.
 // O(len(facts)) per call — fine at ~30 facts/tick.
 func factIDsForDomain(facts []model.Fact, d model.Domain) []string {

--- a/engine/fact_builders.go
+++ b/engine/fact_builders.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"strings"
 	"time"
 
 	"github.com/ftahirops/xtop/model"
@@ -108,8 +109,9 @@ func stampFactBaselines(result *model.AnalysisResult, hist *History) {
 }
 
 // stampFactDurations mirrors Evidence.SustainedForSec into the matching
-// Fact.Duration on each RCAEntry. Facts and Evidence share the same ID
-// convention (cpu.psi.avg10 etc.), so the join is by-key.
+// Fact.Duration on each RCAEntry. Facts and Evidence usually share the same ID,
+// so the join is by-key; PSI is the exception (evidence "<d>.psi" vs fact
+// "<d>.psi.avg10"), handled by a suffix fallback below.
 //
 // NEXTGEN Phase 4: the temporal-ordering gate reads Fact.Duration to
 // decide if a candidate's evidence sustained long enough to count.
@@ -130,7 +132,14 @@ func stampFactDurations(result *model.AnalysisResult) {
 		}
 		for j := range entry.Facts {
 			f := &entry.Facts[j]
-			if sec, ok := susByID[f.ID]; ok {
+			sec, ok := susByID[f.ID]
+			if !ok && strings.HasSuffix(f.ID, ".avg10") {
+				// PSI facts are emitted as "<domain>.psi.avg10" but the paired
+				// evidence is "<domain>.psi" — fall back to the base ID so PSI
+				// durations get stamped (temporal gate depends on this).
+				sec, ok = susByID[strings.TrimSuffix(f.ID, ".avg10")]
+			}
+			if ok {
 				f.Duration = time.Duration(sec * float64(time.Second))
 			}
 		}

--- a/engine/narrative.go
+++ b/engine/narrative.go
@@ -23,7 +23,10 @@ var narrativeTemplates = []narrativeRule{
 	{ids: []string{"mem.swap.activity", "io.psi"}, text: "Memory pressure causing IO storm via swap thrashing", priority: 95},
 	{ids: []string{"mem.reclaim.direct", "io.disk.latency"}, text: "Memory reclaim driving disk latency", priority: 93},
 	{ids: []string{"mem.oom.kills"}, text: "OOM crisis — kernel killing processes to free memory", priority: 92},
-	{ids: []string{"mem.swap.activity", "mem.psi", "io.disk.latency"}, minMatch: 2, text: "Memory pressure cascading into IO latency via swap", priority: 90},
+	// All three required: a "via swap" narrative must have swap evidence. With
+	// minMatch:2 the non-swap pair (mem.psi + io.disk.latency) fired this on hosts
+	// with no swap activity at all.
+	{ids: []string{"mem.swap.activity", "mem.psi", "io.disk.latency"}, text: "Memory pressure cascading into IO latency via swap", priority: 90},
 
 	// CPU multi-signal
 	{ids: []string{"cpu.cgroup.throttle", "cpu.runqueue"}, text: "CPU throttle cascade — cgroup limits saturating run queue", priority: 80},

--- a/engine/patterns.go
+++ b/engine/patterns.go
@@ -105,7 +105,9 @@ var patternLibrary = []Pattern{
 		Priority: 75,
 		Conditions: []PatternCondition{
 			{EvidenceID: "io.disk.util"},
-			{EvidenceID: "io.dstate"},
+			// The narrative asserts D-state threads — require the D-state signal
+			// so util+latency alone can't claim it.
+			{EvidenceID: "io.dstate", Required: true},
 			{EvidenceID: "io.disk.latency"},
 		},
 		MinMatch:  2,
@@ -126,7 +128,9 @@ var patternLibrary = []Pattern{
 		Name:     "VM Noisy Neighbor",
 		Priority: 65,
 		Conditions: []PatternCondition{
-			{EvidenceID: "cpu.steal", MinStrength: 0.1},
+			// Steal is the DEFINING cause — required, so CPU PSI alone can't
+			// print "hypervisor stealing CPU" on a locally-saturated host.
+			{EvidenceID: "cpu.steal", MinStrength: 0.1, Required: true},
 			{EvidenceID: "cpu.psi"},
 		},
 		MinMatch:  1,
@@ -190,8 +194,10 @@ var patternLibrary = []Pattern{
 		Name:     "Network Congestion",
 		Priority: 60,
 		Conditions: []PatternCondition{
-			{EvidenceID: "net.tcp.retrans"},
-			{EvidenceID: "net.drops"},
+			// The narrative asserts both retransmits AND drops — require both so
+			// drops+softirq can't claim "retransmits", nor retrans+softirq claim drops.
+			{EvidenceID: "net.tcp.retrans", Required: true},
+			{EvidenceID: "net.drops", Required: true},
 			{EvidenceID: "net.softirq"},
 		},
 		MinMatch:  2,
@@ -340,7 +346,9 @@ var patternLibrary = []Pattern{
 		Name:     "VM CPU Throttle",
 		Priority: 65,
 		Conditions: []PatternCondition{
-			{EvidenceID: "pve.vm.throttle"},
+			// Real cgroup throttling is required — guest CPU PSI alone doesn't
+			// prove the VM is hitting its CPU limit.
+			{EvidenceID: "pve.vm.throttle", Required: true},
 			{EvidenceID: "pve.vm.cpupsi"},
 		},
 		MinMatch:  1,
@@ -350,7 +358,9 @@ var patternLibrary = []Pattern{
 		Name:     "VM Memory Pressure",
 		Priority: 62,
 		Conditions: []PatternCondition{
-			{EvidenceID: "pve.vm.memlimit"},
+			// "Near memory limit" requires the limit signal — PSI+swap alone
+			// can't establish the guest is close to its cap.
+			{EvidenceID: "pve.vm.memlimit", Required: true},
 			{EvidenceID: "pve.vm.mempsi"},
 			{EvidenceID: "pve.vm.swap"},
 		},

--- a/engine/patterns.go
+++ b/engine/patterns.go
@@ -125,8 +125,11 @@ var patternLibrary = []Pattern{
 		Narrative: "Writeback flood — dirty page flush driving IO stalls",
 	},
 	{
-		Name:     "VM Noisy Neighbor",
-		Priority: 65,
+		Name: "VM Noisy Neighbor",
+		// Priority 79: above CPU Oversubscription (78). Stolen CPU also inflates
+		// the run queue, so oversubscription would otherwise mask the real cause.
+		// Safe because cpu.steal is Required — this only wins when steal is real.
+		Priority: 79,
 		Conditions: []PatternCondition{
 			// Steal is the DEFINING cause — required, so CPU PSI alone can't
 			// print "hypervisor stealing CPU" on a locally-saturated host.
@@ -217,8 +220,11 @@ var patternLibrary = []Pattern{
 		Name:     "Conntrack Exhaustion",
 		Priority: 55,
 		Conditions: []PatternCondition{
-			{EvidenceID: "net.conntrack"},
-			{EvidenceID: "net.drops"},
+			// Table fullness is the defining signal; the drops must be
+			// conntrack-specific — generic NIC/qdisc net.drops don't indicate
+			// conntrack saturation.
+			{EvidenceID: "net.conntrack", Required: true},
+			{EvidenceID: "net.conntrack.drops"},
 		},
 		MinMatch:  2,
 		Narrative: "Conntrack exhaustion — connection tracking table saturated",

--- a/engine/patterns.go
+++ b/engine/patterns.go
@@ -52,7 +52,10 @@ var patternLibrary = []Pattern{
 		Name:     "Memory-Induced IO Storm",
 		Priority: 90,
 		Conditions: []PatternCondition{
-			{EvidenceID: "mem.swap.activity"},
+			// Swap activity is the DEFINING cause here — without it this is just
+			// disk IO, not swap thrashing. Required so the generic io.* co-signals
+			// can't fire the swap narrative on their own.
+			{EvidenceID: "mem.swap.activity", Required: true},
 			{EvidenceID: "io.psi"},
 			{EvidenceID: "io.disk.latency"},
 		},

--- a/engine/rca.go
+++ b/engine/rca.go
@@ -370,6 +370,16 @@ func AnalyzeRCA(curr *model.Snapshot, rates *model.RateSnapshot, hist *History, 
 	// proc host — within the engine's per-tick budget.
 	result.Entities = BuildEntityGraph(curr)
 
+	// Readiness #2: detect config/param drift and correlate it into the RCA
+	// scores BEFORE journal, verification, and finalization — so a drift-driven
+	// boost flows into health, the verifier (via the drift Facts it appends),
+	// and journal suspect selection, instead of mutating the score after the
+	// verdict is already decided. Guarded on e (nil-engine test path is inert).
+	if e != nil {
+		result.Changes = e.detectChanges(curr)
+		correlateConfigDrift(result, result.Changes, curr.Timestamp)
+	}
+
 	// P2.4 / readiness #3: Tier-1 journal RCA runs BEFORE verification and
 	// finalization so its evidence can strengthen VerifiedCauses and the verdict
 	// in the same tick (it was previously injected post-finalize, purely as

--- a/engine/rca.go
+++ b/engine/rca.go
@@ -51,6 +51,10 @@ const (
 	ioDstateBumpScore      = 60   // forced score when D-state count is high
 	fsFullGrowthDampenConf = 0.4  // confidence when FS full but not growing
 	fsFullUsedPctNoGrowth  = 95.0 // usedPct below this + no growth → dampen
+	// Culprit attribution: only blame the memory hog for IO when swap/reclaim is
+	// meaningful (not a trace), otherwise the real IO writer is the culprit.
+	ioCulpritSwapMinMBs     = 1.0   // MB/s swap-in to attribute IO to memory
+	ioCulpritReclaimMinRate = 100.0 // pages/s direct reclaim to attribute IO to memory
 
 	// --- Memory domain ---
 	memOOMMinScore          = 70    // floor score when OOM detected + trust gate

--- a/engine/rca.go
+++ b/engine/rca.go
@@ -377,6 +377,7 @@ func AnalyzeRCA(curr *model.Snapshot, rates *model.RateSnapshot, hist *History, 
 	// verdict is already decided. Guarded on e (nil-engine test path is inert).
 	if e != nil {
 		result.Changes = e.detectChanges(curr)
+		// curr.Timestamp (snapshot-aligned) is intentional; drift recency uses abs age.
 		correlateConfigDrift(result, result.Changes, curr.Timestamp)
 	}
 
@@ -583,6 +584,12 @@ func AnalyzeRCA(curr *model.Snapshot, rates *model.RateSnapshot, hist *History, 
 
 	// Narrative engine: build human-readable root cause explanation
 	result.Narrative = BuildNarrative(result, curr, rates)
+
+	// Inject config-drift remediation suggestions gathered during correlation
+	// (which ran before the narrative existed) now that the narrative is built.
+	if result.Narrative != nil && len(result.ConfigDriftSuggestions) > 0 {
+		result.Narrative.Evidence = append(result.Narrative.Evidence, result.ConfigDriftSuggestions...)
+	}
 
 	// Enrich narrative with app-specific context (e.g., "MySQL slow because IO")
 	if result.Narrative != nil && curr != nil {

--- a/engine/rca.go
+++ b/engine/rca.go
@@ -370,6 +370,14 @@ func AnalyzeRCA(curr *model.Snapshot, rates *model.RateSnapshot, hist *History, 
 	// proc host — within the engine's per-tick budget.
 	result.Entities = BuildEntityGraph(curr)
 
+	// P2.4 / readiness #3: Tier-1 journal RCA runs BEFORE verification and
+	// finalization so its evidence can strengthen VerifiedCauses and the verdict
+	// in the same tick (it was previously injected post-finalize, purely as
+	// after-the-fact context). Needs result.RCA (scored suspects) and
+	// result.Entities, both available here. Best-effort; no-op when no journal
+	// query fn is configured (e.g. the test path).
+	injectJournalTier1(result, curr, e)
+
 	// NEXTGEN Phase 4: derive candidates from each RCA entry and run
 	// them through the verifier. Output is VerifiedCauses — abstaining
 	// by default (Tier D) when proof is weak. Runs additive to the
@@ -633,12 +641,6 @@ func AnalyzeRCA(curr *model.Snapshot, rates *model.RateSnapshot, hist *History, 
 	// visually contradict the health verdict.
 	// Gate-passing paths (Health != Inconclusive) are unaffected.
 	clampInconclusiveScore(result)
-
-	// P2.4: Tier-1 journal RCA — on-demand journal evidence for the top
-	// suspect services identified above. Runs AFTER all suspects are known
-	// and AFTER result.Entities is built so InjectJournalEvidence can scope
-	// Facts to the right entity. Best-effort: never fails the tick.
-	injectJournalTier1(result, curr, e)
 
 	// NEXTGEN Phase 5: persist the frame to the corpus for offline
 	// replay. Best-effort, dedup'd to 1 write/sec, only triggers on

--- a/engine/rca.go
+++ b/engine/rca.go
@@ -397,7 +397,14 @@ func AnalyzeRCA(curr *model.Snapshot, rates *model.RateSnapshot, hist *History, 
 		case entry.TopCgroup != "":
 			c.RootEntityID = "cgroup:" + entry.TopCgroup
 		}
-		result.VerifiedCauses = append(result.VerifiedCauses, v.Verify(c, result.Facts, result.Entities))
+		vc := v.Verify(c, result.Facts, result.Entities)
+		result.VerifiedCauses = append(result.VerifiedCauses, vc)
+		// Additive verification: record whether the PRIMARY bottleneck's cause
+		// was confirmed, so the UI/API can label an unverified verdict. Health
+		// remains score-driven (Finding #4: additive + label).
+		if entry.Bottleneck == result.PrimaryBottleneck {
+			result.PrimaryVerified = isVerifiedTier(vc.Tier)
+		}
 	}
 
 	// NEXTGEN Phase 1B: the score-band Health decision is owned by

--- a/engine/rca_blame_test.go
+++ b/engine/rca_blame_test.go
@@ -1,0 +1,72 @@
+//go:build linux
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/ftahirops/xtop/model"
+)
+
+// TestBlameMemorySlabLeak: when the cause is a kernel slab leak, WHO must point
+// at kernel slab, not an innocent top-RSS userspace process (WHO/WHY must agree).
+func TestBlameMemorySlabLeak(t *testing.T) {
+	result := &model.AnalysisResult{RCA: []model.RCAEntry{{
+		Bottleneck: BottleneckMemory,
+		EvidenceV2: []model.Evidence{{ID: "mem.slab.leak", Strength: 0.8, Severity: model.SeverityCrit}},
+	}}}
+	rates := &model.RateSnapshot{ProcessRates: []model.ProcessRate{
+		{Comm: "innocent-app", PID: 42, MemPct: 40, RSS: 1 << 30},
+	}}
+
+	entries := blameMemory(result, rates)
+	if len(entries) == 0 {
+		t.Fatal("no blame entries")
+	}
+	if entries[0].Comm == "innocent-app" {
+		t.Fatalf("slab leak blamed on innocent userspace process %q instead of kernel slab", entries[0].Comm)
+	}
+	if entries[0].Comm != "kernel-slab" {
+		t.Fatalf("expected kernel-slab as top blame, got %q", entries[0].Comm)
+	}
+}
+
+// TestBlameMemoryNoSlab: without a slab leak, normal top-RSS blame stands.
+func TestBlameMemoryNoSlab(t *testing.T) {
+	result := &model.AnalysisResult{RCA: []model.RCAEntry{{
+		Bottleneck: BottleneckMemory,
+		EvidenceV2: []model.Evidence{{ID: "mem.available.low", Strength: 0.8, Severity: model.SeverityCrit}},
+	}}}
+	rates := &model.RateSnapshot{ProcessRates: []model.ProcessRate{
+		{Comm: "hungry-app", PID: 42, MemPct: 40, RSS: 1 << 30},
+	}}
+	entries := blameMemory(result, rates)
+	if len(entries) == 0 || entries[0].Comm != "hungry-app" {
+		t.Fatalf("expected hungry-app as top blame without slab leak, got %v", entries)
+	}
+}
+
+// TestBlameCPUStealAlignsWithNarrative: when the cpu.steal evidence is active
+// (so the narrative says hypervisor), WHO must include the hypervisor entry —
+// even in the band where steal% <= busy%*0.3, which the old ad-hoc threshold
+// missed, producing a WHO/WHY contradiction.
+func TestBlameCPUStealAlignsWithNarrative(t *testing.T) {
+	result := &model.AnalysisResult{RCA: []model.RCAEntry{{
+		Bottleneck: BottleneckCPU,
+		EvidenceV2: []model.Evidence{{ID: "cpu.steal", Strength: 0.3, Severity: model.SeverityWarn}},
+	}}}
+	// steal 6% with busy 90%: 6 <= 90*0.3 (27), so the old threshold added no
+	// hypervisor entry despite the steal narrative.
+	rates := &model.RateSnapshot{CPUStealPct: 6, CPUBusyPct: 90}
+
+	entries := blameCPU(result, rates)
+	found := false
+	for _, e := range entries {
+		if e.Comm == "hypervisor-steal" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("cpu.steal narrative active but WHO has no hypervisor-steal entry (WHO/WHY diverge)")
+	}
+}

--- a/engine/rca_confidence_test.go
+++ b/engine/rca_confidence_test.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/ftahirops/xtop/model"
+)
+
+// TestConfidenceReflectsStrength reproduces the decoupled-confidence bug: three
+// barely-fired signals (strength ~0.35) produced the same ~98% confidence as
+// three maxed signals, because domainConfidence used only the fired-group count
+// and measurement confidence, never signal strength. A domain whose strongest
+// evidence is weak must not be shown at 93%+.
+func TestConfidenceReflectsStrength(t *testing.T) {
+	mk := func(str float64) []model.Evidence {
+		return []model.Evidence{
+			{ID: "a", Strength: str, Confidence: 0.9},
+			{ID: "b", Strength: str, Confidence: 0.9},
+			{ID: "c", Strength: str, Confidence: 0.9},
+		}
+	}
+	strong := domainConfidence(mk(0.95))
+	weak := domainConfidence(mk(0.35))
+
+	if weak >= strong {
+		t.Fatalf("weak-evidence confidence %.3f should be below strong-evidence %.3f", weak, strong)
+	}
+	if weak > 0.7 {
+		t.Fatalf("barely-fired evidence must not yield high confidence, got %.3f", weak)
+	}
+	if strong < 0.9 {
+		t.Fatalf("strong evidence should keep high confidence, got %.3f", strong)
+	}
+}

--- a/engine/rca_configdrift_order_test.go
+++ b/engine/rca_configdrift_order_test.go
@@ -4,6 +4,7 @@ package engine
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ftahirops/xtop/model"
 )
@@ -15,5 +16,38 @@ func TestDetectChangesNoDetectors(t *testing.T) {
 	got := e.detectChanges(&model.Snapshot{})
 	if len(got) != 0 {
 		t.Fatalf("expected no changes with no detectors, got %d", len(got))
+	}
+}
+
+// TestConfigDriftBoostAffectsHealth pins the ordering invariant: correlating
+// config drift BEFORE finalize must let the boost carry a near-threshold
+// score across the degraded band so finalize reads the boosted score, not
+// the pre-boost one.
+func TestConfigDriftBoostAffectsHealth(t *testing.T) {
+	now := time.Now()
+
+	// Memory anomaly whose score sits just under the degraded band (25); the
+	// config-drift boost should carry it over so finalize reads it as degraded.
+	result := makeMemoryAnomalyResult(23)
+	result.Health = model.HealthOK
+
+	changes := []model.SystemChange{{
+		Type:   "config_drift_memory",
+		Detail: "vm.swappiness: 60 → 100",
+		Domain: "memory",
+		When:   now.Add(-45 * time.Second),
+	}}
+
+	// Order under test — correlate BEFORE finalize.
+	correlateConfigDrift(result, changes, now)
+	var ctx finalizationCtx
+	if len(result.RCA) > 0 {
+		ctx.primary = &result.RCA[0]
+	}
+	finalizeResult(result, &ctx, nil)
+
+	if result.PrimaryScore < rcaScoreDegraded {
+		t.Fatalf("config-drift boost did not lift PrimaryScore across the degraded band: score=%d health=%v",
+			result.PrimaryScore, result.Health)
 	}
 }

--- a/engine/rca_configdrift_order_test.go
+++ b/engine/rca_configdrift_order_test.go
@@ -3,6 +3,7 @@
 package engine
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -22,32 +23,65 @@ func TestDetectChangesNoDetectors(t *testing.T) {
 // TestConfigDriftBoostAffectsHealth pins the ordering invariant: correlating
 // config drift BEFORE finalize must let the boost carry a near-threshold
 // score across the degraded band so finalize reads the boosted score, not
-// the pre-boost one.
+// the pre-boost one. A no-drift control proves it's the boost — not the
+// seeded score — that crosses the band.
 func TestConfigDriftBoostAffectsHealth(t *testing.T) {
 	now := time.Now()
-
-	// Memory anomaly whose score sits just under the degraded band (25); the
-	// config-drift boost should carry it over so finalize reads it as degraded.
-	result := makeMemoryAnomalyResult(23)
-	result.Health = model.HealthOK
-
-	changes := []model.SystemChange{{
+	drift := []model.SystemChange{{
 		Type:   "config_drift_memory",
 		Detail: "vm.swappiness: 60 → 100",
 		Domain: "memory",
 		When:   now.Add(-45 * time.Second),
 	}}
 
-	// Order under test — correlate BEFORE finalize.
-	correlateConfigDrift(result, changes, now)
-	var ctx finalizationCtx
-	if len(result.RCA) > 0 {
-		ctx.primary = &result.RCA[0]
+	// Seed a memory bottleneck whose score sits JUST below the degraded band.
+	mk := func() *model.AnalysisResult {
+		r := makeMemoryAnomalyResult(60) // arg is recentSec, not score
+		r.RCA[0].Score = rcaScoreDegraded - 2 // 23
+		r.PrimaryScore = rcaScoreDegraded - 2
+		return r
 	}
-	finalizeResult(result, &ctx, nil)
 
-	if result.PrimaryScore < rcaScoreDegraded {
-		t.Fatalf("config-drift boost did not lift PrimaryScore across the degraded band: score=%d health=%v",
-			result.PrimaryScore, result.Health)
+	// With a matching drift, the boost must carry the score across the band.
+	boosted := mk()
+	correlateConfigDrift(boosted, drift, now)
+	if boosted.PrimaryScore < rcaScoreDegraded {
+		t.Fatalf("config-drift boost did not cross the degraded band: %d < %d", boosted.PrimaryScore, rcaScoreDegraded)
+	}
+
+	// Control: no drift → score stays below the band (proves the boost, not the seed, crossed it).
+	control := mk()
+	correlateConfigDrift(control, nil, now)
+	if control.PrimaryScore >= rcaScoreDegraded {
+		t.Fatalf("control with no drift wrongly crossed the band: %d", control.PrimaryScore)
+	}
+}
+
+// TestConfigDriftSuggestionSurvivesNilNarrative proves the "SUGGESTED: ..."
+// remediation line is stashed on result.ConfigDriftSuggestions when
+// correlateConfigDrift runs before the narrative exists (the real pipeline's
+// ordering), so AnalyzeRCA can inject it into Narrative.Evidence afterward.
+func TestConfigDriftSuggestionSurvivesNilNarrative(t *testing.T) {
+	now := time.Now()
+	result := makeMemoryAnomalyResult(60)
+	result.Narrative = nil // matches the real pipeline at correlate time
+
+	changes := []model.SystemChange{{
+		Type:   "config_drift_memory",
+		Detail: "vm.swappiness: 60 → 100", // maps to a non-empty suggestedRemediation
+		Domain: "memory",
+		When:   now.Add(-45 * time.Second),
+	}}
+
+	correlateConfigDrift(result, changes, now)
+
+	found := false
+	for _, s := range result.ConfigDriftSuggestions {
+		if strings.HasPrefix(s, "SUGGESTED: ") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("config-drift remediation not stashed for post-narrative injection; got %v", result.ConfigDriftSuggestions)
 	}
 }

--- a/engine/rca_configdrift_order_test.go
+++ b/engine/rca_configdrift_order_test.go
@@ -1,0 +1,19 @@
+//go:build linux
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/ftahirops/xtop/model"
+)
+
+// detectChanges must be callable and return an empty slice without panicking
+// when the engine has no detectors configured (the common test path).
+func TestDetectChangesNoDetectors(t *testing.T) {
+	e := &Engine{} // no changeDetector / configDrift / paramDriftDetector
+	got := e.detectChanges(&model.Snapshot{})
+	if len(got) != 0 {
+		t.Fatalf("expected no changes with no detectors, got %d", len(got))
+	}
+}

--- a/engine/rca_cpu.go
+++ b/engine/rca_cpu.go
@@ -236,13 +236,11 @@ func analyzeCPU(db *AdaptiveThresholdDB, curr *model.Snapshot, rates *model.Rate
 			r.Score = cpuSafeMaxScore
 		}
 	}
-	if stealPct > cpuStealBonusThreshold && v2TrustGate(r.EvidenceV2) {
-		r.Score += cpuStealBonusScore
-	}
-	if r.Score < rcaT.ScoreFloor {
-		r.Score = 0
-	}
-	cap100(&r.Score)
+	// Steal bonus augments an already-real CPU bottleneck; it must not resurrect a
+	// floored score, and requires the cpu.steal evidence to have actually fired
+	// (not merely any trusted evidence via v2TrustGate).
+	stealGate := stealPct > cpuStealBonusThreshold && evidenceFired(r.EvidenceV2, "cpu.steal")
+	r.Score = applyScoreBonus(r.Score, cpuStealBonusScore, rcaT.ScoreFloor, stealGate)
 	r.EvidenceGroups = evidenceGroupsFired(r.EvidenceV2, evidenceStrengthMin)
 	r.Checks = evidenceToChecks(r.EvidenceV2)
 

--- a/engine/rca_cpu.go
+++ b/engine/rca_cpu.go
@@ -18,10 +18,17 @@ func analyzeCPU(db *AdaptiveThresholdDB, curr *model.Snapshot, rates *model.Rate
 	if nCPUs == 0 {
 		nCPUs = 1
 	}
-	// Use Load1 for run queue: kernel-smoothed average, not instantaneous procs_running
-	// (Gregg: Load1 is already a 1-minute EWMA, less noise than point-in-time sample)
-	rqRatio := curr.Global.CPU.LoadAvg.Load1 / float64(nCPUs)
-	running := curr.Global.CPU.LoadAvg.Load1 // for display
+	// Run queue = instantaneous runnable tasks (procs_running from /proc/loadavg),
+	// NOT Load1. Load1 is a 1-minute EWMA that badly under-reports short saturation
+	// bursts: 13 runnable on 6 cores (ratio 2.17, saturated) shows as Load1 3.2
+	// (ratio 0.53, under threshold), which starved the cpu.runqueue evidence and
+	// mis-routed pattern selection. Fall back to Load1 only if procs_running is
+	// unavailable (0).
+	running := float64(curr.Global.CPU.LoadAvg.Running)
+	if running == 0 {
+		running = curr.Global.CPU.LoadAvg.Load1
+	}
+	rqRatio := running / float64(nCPUs)
 
 	var ctxRate, busyPct, stealPct, iowaitPct float64
 	var maxThrottlePct float64

--- a/engine/rca_fact_stamp_test.go
+++ b/engine/rca_fact_stamp_test.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+package engine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ftahirops/xtop/model"
+)
+
+// TestStampFactDurationsPSISuffix reproduces readiness-review Finding #5: PSI
+// evidence uses ID "cpu.psi" but the paired Fact uses "cpu.psi.avg10", so the
+// by-ID join never stamped PSI fact durations — weakening the temporal-ordering
+// verifier on the core pressure signals.
+func TestStampFactDurationsPSISuffix(t *testing.T) {
+	result := &model.AnalysisResult{RCA: []model.RCAEntry{{
+		EvidenceV2: []model.Evidence{
+			{ID: "cpu.psi", SustainedForSec: 30},
+			{ID: "mem.reclaim.direct", SustainedForSec: 10}, // exact-match control
+		},
+		Facts: []model.Fact{
+			{ID: "cpu.psi.avg10"},
+			{ID: "mem.reclaim.direct"},
+		},
+	}}}
+
+	stampFactDurations(result)
+
+	if got := result.RCA[0].Facts[0].Duration; got != 30*time.Second {
+		t.Fatalf("PSI fact (cpu.psi.avg10) duration not stamped from cpu.psi evidence: got %v", got)
+	}
+	if got := result.RCA[0].Facts[1].Duration; got != 10*time.Second {
+		t.Fatalf("exact-match fact duration regressed: got %v", got)
+	}
+}

--- a/engine/rca_io.go
+++ b/engine/rca_io.go
@@ -109,9 +109,13 @@ func analyzeIO(db *AdaptiveThresholdDB, curr *model.Snapshot, rates *model.RateS
 		float64(worstQueueDepth), w, c, true, 0.75,
 		fmt.Sprintf("queue depth=%d (%s)", worstQueueDepth, worstQueueDev), "1s",
 		nil, nil))
+	// Thresholds are in MB (warn 5, crit 20); mem.Writeback is bytes, so convert.
+	// Previously the raw byte count was compared against 5/20, pinning strength
+	// at 1.0 on every host with any writeback at all.
 	w, c = thresholdAdaptive(db, "io.writeback", 5, 20, curr)
+	writebackMB := float64(mem.Writeback) / (1024 * 1024)
 	r.EvidenceV2 = append(r.EvidenceV2, emitEvidence("io.writeback", model.DomainIO,
-		float64(mem.Writeback), w, c, true, 0.7,
+		writebackMB, w, c, true, 0.7,
 		fmt.Sprintf("writeback=%s", formatB(mem.Writeback)), "1s",
 		nil, nil))
 
@@ -131,14 +135,19 @@ func analyzeIO(db *AdaptiveThresholdDB, curr *model.Snapshot, rates *model.RateS
 		buildFact("io.disk.util", "util_pct", model.DomainIO, worstUtil, "%", utilWarn, 0.85, now, "diskstats", nil),
 		buildFactScoped("io.disk.queuedepth", "queue_depth", model.DomainIO, float64(worstQueueDepth), "count", qdWarn, 0.75, now, "diskstats",
 			deviceEntityID(worstQueueDev), map[string]string{"device": worstQueueDev}),
-		buildFact("io.writeback", "writeback_bytes", model.DomainIO, float64(mem.Writeback), "bytes", wbWarn, 0.7, now, "procfs", nil),
+		buildFact("io.writeback", "writeback_mb", model.DomainIO, float64(mem.Writeback)/(1024*1024), "MB", wbWarn, 0.7, now, "procfs", nil),
 	)
 
 	// Filesystem full: only fire if there is actual growth (not just a large static FS)
 	if fsFull {
 		w, c = thresholdAdaptive(db, "io.fsfull", 85, 95, curr)
 		conf := 0.9
-		if worstFreePct > fsFullUsedPctNoGrowth && worstGrowthBPS < 1024 {
+		// Dampen confidence when the FS is full-ish but static: usedPct below the
+		// no-growth threshold AND not actively growing. Was comparing worstFreePct
+		// (free%) against the used% constant (95) — always false, so a static
+		// 85-95%-full mount hijacked the narrative at full 0.9 confidence.
+		usedPct := 100 - worstFreePct
+		if usedPct < fsFullUsedPctNoGrowth && worstGrowthBPS < 1024 {
 			conf = fsFullGrowthDampenConf // dampen if not actively growing
 		}
 		r.EvidenceV2 = append(r.EvidenceV2, emitEvidence("io.fsfull", model.DomainIO,

--- a/engine/rca_io.go
+++ b/engine/rca_io.go
@@ -262,8 +262,12 @@ func findIOCulprit(curr *model.Snapshot, rates *model.RateSnapshot, r *model.RCA
 	// 3) D-state process, 4) top IO reader.
 	// Always exclude xtop itself and kernel threads.
 
-	// If IO is caused by memory reclaim (swap storm), blame the memory hog, not IO victim
-	if rates != nil && (rates.SwapInRate > 0 || rates.DirectReclaimRate > 0) {
+	// If IO is caused by memory reclaim (swap storm), blame the memory hog, not
+	// the IO victim — but only when swap/reclaim is MEANINGFUL. The old `> 0`
+	// gate let a trace of swap-in hijack culprit selection away from the real
+	// heavy writer. Thresholds mirror the swap-activity warn (1 MB/s) and an
+	// active-reclaim level (100 pages/s).
+	if rates != nil && (rates.SwapInRate >= ioCulpritSwapMinMBs || rates.DirectReclaimRate >= ioCulpritReclaimMinRate) {
 		var maxRSS uint64
 		for _, pr := range rates.ProcessRates {
 			if isKernelThread(pr.Comm) || isSelfProcess(pr.Comm) {

--- a/engine/rca_io_culprit_test.go
+++ b/engine/rca_io_culprit_test.go
@@ -1,0 +1,46 @@
+//go:build linux
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/ftahirops/xtop/model"
+)
+
+// TestIOCulpritIgnoresNegligibleSwap reproduces the culprit misattribution:
+// the memory-hog branch fired on ANY swap-in > 0, so a trace of swap made it
+// blame the top-RSS process instead of the actual heavy IO writer.
+func TestIOCulpritIgnoresNegligibleSwap(t *testing.T) {
+	rates := &model.RateSnapshot{
+		SwapInRate: 0.01, // negligible
+		ProcessRates: []model.ProcessRate{
+			{Comm: "db-writer", PID: 10, WriteMBs: 50, RSS: 100 << 20},
+			{Comm: "cache-hog", PID: 20, WriteMBs: 0, RSS: 8 << 30},
+		},
+	}
+	r := &model.RCAEntry{Bottleneck: BottleneckIO}
+	findIOCulprit(&model.Snapshot{}, rates, r)
+
+	if r.TopProcess != "db-writer" {
+		t.Fatalf("negligible swap misattributed IO culprit to %q; want the real writer db-writer", r.TopProcess)
+	}
+}
+
+// TestIOCulpritRealSwapBlamesMemoryHog guards the real case: with genuine swap
+// activity the memory hog IS the cause of the IO.
+func TestIOCulpritRealSwapBlamesMemoryHog(t *testing.T) {
+	rates := &model.RateSnapshot{
+		SwapInRate: 8, // real swap storm
+		ProcessRates: []model.ProcessRate{
+			{Comm: "db-writer", PID: 10, WriteMBs: 50, RSS: 100 << 20},
+			{Comm: "cache-hog", PID: 20, WriteMBs: 0, RSS: 8 << 30},
+		},
+	}
+	r := &model.RCAEntry{Bottleneck: BottleneckIO}
+	findIOCulprit(&model.Snapshot{}, rates, r)
+
+	if r.TopProcess != "cache-hog" {
+		t.Fatalf("real swap storm should blame the memory hog cache-hog, got %q", r.TopProcess)
+	}
+}

--- a/engine/rca_io_units_test.go
+++ b/engine/rca_io_units_test.go
@@ -1,0 +1,87 @@
+//go:build linux
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/ftahirops/xtop/model"
+)
+
+func ioEvidence(entry model.RCAEntry, id string) (model.Evidence, bool) {
+	for _, ev := range entry.EvidenceV2 {
+		if ev.ID == id {
+			return ev, true
+		}
+	}
+	return model.Evidence{}, false
+}
+
+// TestWritebackThresholdUnit reproduces the unit bug: mem.Writeback is in BYTES
+// but io.writeback used warn/crit of 5/20, so any writeback above 20 bytes
+// pinned strength at 1.0 on every host. A few MB of writeback is normal and
+// must not fire; a large flush must.
+func TestWritebackThresholdUnit(t *testing.T) {
+	mk := func(wb uint64) model.RCAEntry {
+		curr := &model.Snapshot{}
+		curr.Global.Memory.Total = 16 * 1024 * 1024 * 1024
+		curr.Global.Memory.Writeback = wb
+		return analyzeIO(nil, curr, &model.RateSnapshot{}, systemProfile{}, effectiveRCAThresholds{})
+	}
+
+	// 2 MB writeback — normal, must not fire.
+	small, ok := ioEvidence(mk(2*1024*1024), "io.writeback")
+	if !ok {
+		t.Fatal("no io.writeback evidence emitted")
+	}
+	if small.Strength > 0 {
+		t.Fatalf("2MB writeback wrongly fired (strength=%v) — threshold still in bytes", small.Strength)
+	}
+
+	// 60 MB writeback — genuine flush pressure, must fire.
+	big, _ := ioEvidence(mk(60*1024*1024), "io.writeback")
+	if big.Strength <= 0 {
+		t.Fatalf("60MB writeback did not fire (strength=%v)", big.Strength)
+	}
+}
+
+// TestFsFullDampenerStaticMount reproduces the FREE%-vs-USED% dampener bug: a
+// filesystem that is full-ish (88% used) but NOT growing should have its
+// confidence dampened, so it doesn't hijack the narrative at 0.9. The dampener
+// compared worstFreePct (12) > 95 — always false — so it was dead code.
+func TestFsFullDampenerStaticMount(t *testing.T) {
+	curr := &model.Snapshot{}
+	rcaT := effectiveRCAThresholds{IoFsFullFreePct: 15} // fsFull when free < 15%
+	// 88% used (free 12%), no growth.
+	rates := &model.RateSnapshot{MountRates: []model.MountRate{
+		{MountPoint: "/data", FreePct: 12, UsedPct: 88, GrowthBytesPerSec: 0},
+	}}
+
+	entry := analyzeIO(nil, curr, rates, systemProfile{}, rcaT)
+	ev, ok := ioEvidence(entry, "io.fsfull")
+	if !ok {
+		t.Fatal("io.fsfull evidence not emitted for an 88%-used mount")
+	}
+	if ev.Confidence >= 0.9 {
+		t.Fatalf("static 88%%-full mount kept high confidence %v — dampener is dead code", ev.Confidence)
+	}
+}
+
+// TestFsFullGrowingMountStaysConfident guards the other side: a full filesystem
+// that IS actively growing must keep high confidence.
+func TestFsFullGrowingMountStaysConfident(t *testing.T) {
+	curr := &model.Snapshot{}
+	rcaT := effectiveRCAThresholds{IoFsFullFreePct: 15}
+	rates := &model.RateSnapshot{MountRates: []model.MountRate{
+		{MountPoint: "/data", FreePct: 12, UsedPct: 88, GrowthBytesPerSec: 5 * 1024 * 1024},
+	}}
+
+	entry := analyzeIO(nil, curr, rates, systemProfile{}, rcaT)
+	ev, ok := ioEvidence(entry, "io.fsfull")
+	if !ok {
+		t.Fatal("io.fsfull evidence not emitted")
+	}
+	if ev.Confidence < 0.9 {
+		t.Fatalf("actively-growing full mount was wrongly dampened to %v", ev.Confidence)
+	}
+}

--- a/engine/rca_memory.go
+++ b/engine/rca_memory.go
@@ -102,7 +102,18 @@ func analyzeMemory(db *AdaptiveThresholdDB, curr *model.Snapshot, rates *model.R
 	w3, c3 := thresholdAdaptive(db, "mem.reclaim.direct", 10, 500, curr)
 	w5, c5 := thresholdAdaptive(db, "mem.major.faults", 10, 200, curr)
 	w6, c6 := thresholdAdaptive(db, "mem.oom.kills", 1, 1, curr)
+	// Aggregate swap activity (in+out MB/s). The pattern/narrative/causal/temporal
+	// layers all key off "mem.swap.activity"; without this emit that ID never fires,
+	// so swap-thrashing patterns matched on their generic co-conditions instead
+	// (labelling pure disk IO as "swap thrashing"). Emit it so those patterns fire
+	// only when swap is genuinely active.
+	wSwap, cSwap := thresholdAdaptive(db, "mem.swap.activity", 1, 20, curr)
+	swapActivity := swapInRate + swapOutRate
 	r.EvidenceV2 = append(r.EvidenceV2,
+		emitEvidence("mem.swap.activity", model.DomainMemory,
+			swapActivity, wSwap, cSwap, true, 0.85,
+			fmt.Sprintf("swap activity=%.1f MB/s (in %.1f + out %.1f)", swapActivity, swapInRate, swapOutRate), "1s",
+			nil, nil),
 		emitEvidence("mem.psi", model.DomainMemory,
 			memSome*100, w, c, true, 0.9,
 			fmt.Sprintf("MEM PSI some=%.1f%% full=%.1f%%", memSome*100, memFull*100), "avg10",
@@ -142,6 +153,7 @@ func analyzeMemory(db *AdaptiveThresholdDB, curr *model.Snapshot, rates *model.R
 		buildFact("mem.reclaim.direct", "direct_reclaim_pages_per_sec", model.DomainMemory, directReclaimRate, "count/s", w3, reclaimConf, now, "vmstat", nil),
 		buildFact("mem.swap.in", "swap_in_mb_per_sec", model.DomainMemory, swapInRate, "MB/s", 1, 0.85, now, "vmstat", nil),
 		buildFact("mem.swap.out", "swap_out_mb_per_sec", model.DomainMemory, swapOutRate, "MB/s", 2, 0.7, now, "vmstat", nil),
+		buildFact("mem.swap.activity", "swap_activity_mb_per_sec", model.DomainMemory, swapActivity, "MB/s", wSwap, 0.85, now, "vmstat", nil),
 		buildFact("mem.major.faults", "major_faults_per_sec", model.DomainMemory, majFaultRate, "count/s", w5, 0.7, now, "vmstat", nil),
 		buildFact("mem.oom.kills", "oom_kills", model.DomainMemory, oomVal, "count", w6, 1.0, now, "vmstat", nil),
 	)

--- a/engine/rca_memory.go
+++ b/engine/rca_memory.go
@@ -109,6 +109,19 @@ func analyzeMemory(db *AdaptiveThresholdDB, curr *model.Snapshot, rates *model.R
 	// only when swap is genuinely active.
 	wSwap, cSwap := thresholdAdaptive(db, "mem.swap.activity", 1, 20, curr)
 	swapActivity := swapInRate + swapOutRate
+
+	// Direct reclaim without PSI confirmation is normal cache-pressure reclaim,
+	// not a "reclaim storm". Gate its STRENGTH (not just confidence) on PSI —
+	// the pattern matcher keys off strength, so a confidence-only dampener let
+	// Direct Reclaim Storm fire with PSI=0.
+	reclaimEv := emitEvidence("mem.reclaim.direct", model.DomainMemory,
+		directReclaimRate, w3, c3, true, reclaimConf,
+		fmt.Sprintf("direct reclaim=%.0f pages/s", directReclaimRate), "1s",
+		nil, nil)
+	if memSome < memPSISomeMinForReclaim {
+		reclaimEv.Strength = 0
+	}
+
 	r.EvidenceV2 = append(r.EvidenceV2,
 		emitEvidence("mem.swap.activity", model.DomainMemory,
 			swapActivity, wSwap, cSwap, true, 0.85,
@@ -122,10 +135,7 @@ func analyzeMemory(db *AdaptiveThresholdDB, curr *model.Snapshot, rates *model.R
 			usedPct, w2, c2, true, 0.9,
 			fmt.Sprintf("MemAvailable=%.1f%% (%s free)", availPct, formatB(mem.Available)), "1s",
 			nil, nil),
-		emitEvidence("mem.reclaim.direct", model.DomainMemory,
-			directReclaimRate, w3, c3, true, reclaimConf, // measured from vmstat, confidence gated by PSI
-			fmt.Sprintf("direct reclaim=%.0f pages/s", directReclaimRate), "1s",
-			nil, nil),
+		reclaimEv,
 		// Split swap: swap-in is worse than swap-out (Gregg: swap-in = demand paging failure)
 		emitEvidence("mem.swap.in", model.DomainMemory,
 			swapInRate, 1, 30, true, 0.85,

--- a/engine/rca_memory.go
+++ b/engine/rca_memory.go
@@ -258,6 +258,49 @@ func analyzeMemory(db *AdaptiveThresholdDB, curr *model.Snapshot, rates *model.R
 	appInjector := NewAppEvidenceInjector()
 	appInjector.InjectMemoryEvidence(db, curr, &r)
 
+	// Proxmox VM-level memory evidence — only emit when actual degradation is
+	// measured. Emitted BEFORE scoring so VM OOM/swap/limit/PSI evidence counts
+	// toward Score, EvidenceGroups, Checks and the memory health verdict (it was
+	// previously appended after scoring and could not affect the result).
+	if pve := curr.Global.Proxmox; pve != nil && pve.IsProxmoxHost {
+		for _, vm := range pve.VMs {
+			if vm.Status != "running" {
+				continue
+			}
+			// OOM kills — always evidence of a real problem
+			if vm.MemOOMKills > 0 {
+				r.EvidenceV2 = append(r.EvidenceV2, emitEvidence("pve.vm.oom", model.DomainMemory,
+					float64(vm.MemOOMKills), 1, 3, false, 0.95,
+					fmt.Sprintf("VM %d (%s) OOM kills=%d", vm.VMID, vm.Name, vm.MemOOMKills), "cgroup",
+					nil, map[string]string{"vmid": fmt.Sprintf("%d", vm.VMID)}))
+			}
+			// Swap only matters if PSI confirms degradation
+			if vm.MemSwapMB > pveSwapMinMB && vm.PSIMemSome > pveSwapMinPSI {
+				r.EvidenceV2 = append(r.EvidenceV2, emitEvidence("pve.vm.swap", model.DomainMemory,
+					float64(vm.MemSwapMB), 100, 1024, false, 0.8,
+					fmt.Sprintf("VM %d (%s) swap=%dMB with pressure", vm.VMID, vm.Name, vm.MemSwapMB), "cgroup",
+					nil, map[string]string{"vmid": fmt.Sprintf("%d", vm.VMID)}))
+			}
+			// Memory near limit only matters if OOM events are happening
+			if vm.MemLimitMB > 0 && vm.MemUsedMB > 0 && vm.MemOOMEvents > 0 {
+				pct := float64(vm.MemUsedMB) / float64(vm.MemLimitMB) * 100
+				if pct > pveMemLimitWarnPct {
+					r.EvidenceV2 = append(r.EvidenceV2, emitEvidence("pve.vm.memlimit", model.DomainMemory,
+						pct, 85, 95, true, 0.75,
+						fmt.Sprintf("VM %d (%s) mem=%.0f%% of limit with OOM events", vm.VMID, vm.Name, pct), "cgroup",
+						nil, map[string]string{"vmid": fmt.Sprintf("%d", vm.VMID)}))
+				}
+			}
+			// Memory PSI — direct proof of degradation
+			if vm.PSIMemSome > pvePSIMemMinSome {
+				r.EvidenceV2 = append(r.EvidenceV2, emitEvidence("pve.vm.mempsi", model.DomainMemory,
+					vm.PSIMemSome, 15, 40, true, 0.7,
+					fmt.Sprintf("VM %d (%s) mem PSI=%.1f%%", vm.VMID, vm.Name, vm.PSIMemSome), "cgroup",
+					nil, map[string]string{"vmid": fmt.Sprintf("%d", vm.VMID)}))
+			}
+		}
+	}
+
 	// v2 scoring
 	v2Score := weightedDomainScore(r.EvidenceV2)
 	if !v2TrustGate(r.EvidenceV2) {
@@ -265,10 +308,6 @@ func analyzeMemory(db *AdaptiveThresholdDB, curr *model.Snapshot, rates *model.R
 	}
 	r.Score = int(v2Score)
 	// Floor score when OOM detected + trust gate passes
-	if oomDetected && v2TrustGate(r.EvidenceV2) && r.Score < rcaT.MemOOMMinScore {
-		r.Score = rcaT.MemOOMMinScore
-	}
-	r.Score = int(v2Score)
 	if oomDetected && v2TrustGate(r.EvidenceV2) && r.Score < rcaT.MemOOMMinScore {
 		r.Score = rcaT.MemOOMMinScore
 	}
@@ -393,46 +432,6 @@ func analyzeMemory(db *AdaptiveThresholdDB, curr *model.Snapshot, rates *model.R
 				maxRSS = p.RSS
 				r.TopProcess = p.Comm
 				r.TopPID = p.PID
-			}
-		}
-	}
-
-	// Proxmox VM-level memory evidence — only emit when actual degradation is measured
-	if pve := curr.Global.Proxmox; pve != nil && pve.IsProxmoxHost {
-		for _, vm := range pve.VMs {
-			if vm.Status != "running" {
-				continue
-			}
-			// OOM kills — always evidence of a real problem
-			if vm.MemOOMKills > 0 {
-				r.EvidenceV2 = append(r.EvidenceV2, emitEvidence("pve.vm.oom", model.DomainMemory,
-					float64(vm.MemOOMKills), 1, 3, false, 0.95,
-					fmt.Sprintf("VM %d (%s) OOM kills=%d", vm.VMID, vm.Name, vm.MemOOMKills), "cgroup",
-					nil, map[string]string{"vmid": fmt.Sprintf("%d", vm.VMID)}))
-			}
-			// Swap only matters if PSI confirms degradation
-			if vm.MemSwapMB > pveSwapMinMB && vm.PSIMemSome > pveSwapMinPSI {
-				r.EvidenceV2 = append(r.EvidenceV2, emitEvidence("pve.vm.swap", model.DomainMemory,
-					float64(vm.MemSwapMB), 100, 1024, false, 0.8,
-					fmt.Sprintf("VM %d (%s) swap=%dMB with pressure", vm.VMID, vm.Name, vm.MemSwapMB), "cgroup",
-					nil, map[string]string{"vmid": fmt.Sprintf("%d", vm.VMID)}))
-			}
-			// Memory near limit only matters if OOM events are happening
-			if vm.MemLimitMB > 0 && vm.MemUsedMB > 0 && vm.MemOOMEvents > 0 {
-				pct := float64(vm.MemUsedMB) / float64(vm.MemLimitMB) * 100
-				if pct > pveMemLimitWarnPct {
-					r.EvidenceV2 = append(r.EvidenceV2, emitEvidence("pve.vm.memlimit", model.DomainMemory,
-						pct, 85, 95, true, 0.75,
-						fmt.Sprintf("VM %d (%s) mem=%.0f%% of limit with OOM events", vm.VMID, vm.Name, pct), "cgroup",
-						nil, map[string]string{"vmid": fmt.Sprintf("%d", vm.VMID)}))
-				}
-			}
-			// Memory PSI — direct proof of degradation
-			if vm.PSIMemSome > pvePSIMemMinSome {
-				r.EvidenceV2 = append(r.EvidenceV2, emitEvidence("pve.vm.mempsi", model.DomainMemory,
-					vm.PSIMemSome, 15, 40, true, 0.7,
-					fmt.Sprintf("VM %d (%s) mem PSI=%.1f%%", vm.VMID, vm.Name, vm.PSIMemSome), "cgroup",
-					nil, map[string]string{"vmid": fmt.Sprintf("%d", vm.VMID)}))
 			}
 		}
 	}

--- a/engine/rca_network.go
+++ b/engine/rca_network.go
@@ -508,13 +508,11 @@ func analyzeNetwork(db *AdaptiveThresholdDB, curr *model.Snapshot, rates *model.
 		r.Score = int(float64(r.Score) * severityMultiplier)
 	}
 
-	if totalDrops > netEvDropsMin && rates.CPUSoftIRQPct > netEvSoftIRQMin && v2TrustGate(r.EvidenceV2) {
-		r.Score += netDropsSoftIRQBonus
-	}
-	if r.Score < rcaT.ScoreFloor {
-		r.Score = 0
-	}
-	cap100(&r.Score)
+	// Drops+softirq bonus: gate on the actual net.drops evidence firing (not the
+	// raw metric above a tiny display minimum) and apply after the floor so it
+	// can't resurrect a sub-threshold network domain.
+	dropsGate := evidenceFired(r.EvidenceV2, "net.drops") && rates.CPUSoftIRQPct > netEvSoftIRQMin
+	r.Score = applyScoreBonus(r.Score, netDropsSoftIRQBonus, rcaT.ScoreFloor, dropsGate)
 	r.EvidenceGroups = evidenceGroupsFired(r.EvidenceV2, evidenceStrengthMin)
 	r.Checks = evidenceToChecks(r.EvidenceV2)
 

--- a/engine/rca_pattern_discipline_test.go
+++ b/engine/rca_pattern_discipline_test.go
@@ -1,0 +1,57 @@
+//go:build linux
+
+package engine
+
+import "testing"
+
+// A specific-cause pattern must NOT fire when only its generic co-signals are
+// present — the defining evidence has to be there. Each negative case fires
+// everything EXCEPT the defining evidence and asserts the named pattern does not win.
+func TestPatternsRequireDefiningEvidence(t *testing.T) {
+	negatives := []struct {
+		name       string // pattern that must NOT match
+		firedNoDef []string
+	}{
+		// SEED-A: hypervisor-steal narrative must need actual steal, not just CPU PSI.
+		{"VM Noisy Neighbor", []string{"cpu.psi"}},
+		// VM CPU throttle must need real throttling, not just guest CPU PSI.
+		{"VM CPU Throttle", []string{"pve.vm.cpupsi"}},
+		// VM memory pressure must need the mem-limit signal, not just PSI+swap.
+		{"VM Memory Pressure", []string{"pve.vm.mempsi", "pve.vm.swap"}},
+		// "D-state threads accumulating" must need io.dstate, not just util+latency.
+		{"Disk IO Saturation", []string{"io.disk.util", "io.disk.latency"}},
+		// "retransmits with packet drops" must need retransmits, not just drops+softirq.
+		{"Network Congestion", []string{"net.drops", "net.softirq"}},
+	}
+	for _, tc := range negatives {
+		pat := MatchPattern(firedResult(tc.firedNoDef...))
+		if pat != nil && pat.Name == tc.name {
+			t.Errorf("%q fired without its defining evidence (fired=%v -> %q)",
+				tc.name, tc.firedNoDef, pat.Narrative)
+		}
+	}
+}
+
+// Positive guards: with the defining evidence present, the pattern SHOULD fire.
+func TestPatternsFireWithDefiningEvidence(t *testing.T) {
+	positives := []struct {
+		name  string
+		fired []string
+	}{
+		{"VM Noisy Neighbor", []string{"cpu.steal", "cpu.psi"}},
+		{"VM CPU Throttle", []string{"pve.vm.throttle", "pve.vm.cpupsi"}},
+		{"VM Memory Pressure", []string{"pve.vm.memlimit", "pve.vm.mempsi", "pve.vm.swap"}},
+		{"Disk IO Saturation", []string{"io.disk.util", "io.dstate", "io.disk.latency"}},
+		{"Network Congestion", []string{"net.tcp.retrans", "net.drops", "net.softirq"}},
+	}
+	for _, tc := range positives {
+		pat := MatchPattern(firedResult(tc.fired...))
+		if pat == nil || pat.Name != tc.name {
+			got := "nil"
+			if pat != nil {
+				got = pat.Name
+			}
+			t.Errorf("%q should fire with %v, got %s", tc.name, tc.fired, got)
+		}
+	}
+}

--- a/engine/rca_pipeline_order_test.go
+++ b/engine/rca_pipeline_order_test.go
@@ -1,0 +1,39 @@
+//go:build linux
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/ftahirops/xtop/model"
+)
+
+// TestProxmoxEvidenceCountedInScoring reproduces readiness-review Finding #1:
+// Proxmox VM memory evidence was appended AFTER scoring / EvidenceGroups / Checks
+// were computed, so a VM OOM could show in EvidenceV2 but never affect the memory
+// verdict. On a healthy host (no base memory evidence fires), the VM's OOM +
+// mem-PSI evidence must still be counted.
+func TestProxmoxEvidenceCountedInScoring(t *testing.T) {
+	curr := &model.Snapshot{}
+	curr.Global.Memory.Total = 16 * 1024 * 1024 * 1024
+	curr.Global.Memory.Available = 8 * 1024 * 1024 * 1024 // healthy: no base evidence fires
+	curr.Global.Proxmox = &model.ProxmoxMetrics{
+		IsProxmoxHost: true,
+		VMs: []model.ProxmoxVM{{
+			VMID: 100, Name: "db", Status: "running",
+			MemOOMKills: 3,  // fires pve.vm.oom
+			PSIMemSome:  50, // fires pve.vm.mempsi (> pvePSIMemMinSome=10)
+		}},
+	}
+
+	entry := analyzeMemory(nil, curr, &model.RateSnapshot{}, systemProfile{}, effectiveRCAThresholds{})
+
+	if entry.EvidenceGroups < 1 {
+		t.Fatalf("Proxmox VM OOM/PSI evidence not counted in EvidenceGroups (got %d) — "+
+			"evidence emitted after scoring", entry.EvidenceGroups)
+	}
+	// The pve evidence must also be present in Checks (derived alongside EvidenceGroups).
+	if len(entry.Checks) == 0 {
+		t.Fatal("Proxmox VM evidence produced no Checks — computed before the pve block")
+	}
+}

--- a/engine/rca_priority_source_test.go
+++ b/engine/rca_priority_source_test.go
@@ -1,0 +1,46 @@
+//go:build linux
+
+package engine
+
+import "testing"
+
+// TestStealBeatsOversubscription: when CPU steal is genuinely present, the
+// hypervisor-steal narrative is the root cause even though run-queue and PSI
+// also fire (stolen time makes tasks pile up). The steal pattern must win over
+// the generic CPU Oversubscription pattern.
+func TestStealBeatsOversubscription(t *testing.T) {
+	pat := MatchPattern(firedResult("cpu.steal", "cpu.psi", "cpu.runqueue"))
+	if pat == nil {
+		t.Fatal("expected a pattern match")
+	}
+	if pat.Name == "CPU Oversubscription" {
+		t.Fatalf("steal scenario masked by oversubscription: %q", pat.Narrative)
+	}
+	if pat.Name != "VM Noisy Neighbor" {
+		t.Fatalf("expected VM Noisy Neighbor to win with real steal, got %q", pat.Name)
+	}
+}
+
+// TestOversubscriptionWithoutSteal: with no steal, run-queue + PSI is honest
+// oversubscription.
+func TestOversubscriptionWithoutSteal(t *testing.T) {
+	pat := MatchPattern(firedResult("cpu.psi", "cpu.runqueue"))
+	if pat == nil || pat.Name != "CPU Oversubscription" {
+		got := "nil"
+		if pat != nil {
+			got = pat.Name
+		}
+		t.Fatalf("expected CPU Oversubscription without steal, got %s", got)
+	}
+}
+
+// TestConntrackExhaustionNeedsConntrackDrops reproduces the wrong-drop-source
+// bug: generic NIC/qdisc packet drops (net.drops) plus a busy conntrack table
+// must NOT be labeled "conntrack exhaustion" — that needs conntrack-specific
+// drops (net.conntrack.drops).
+func TestConntrackExhaustionNeedsConntrackDrops(t *testing.T) {
+	pat := MatchPattern(firedResult("net.conntrack", "net.drops"))
+	if pat != nil && pat.Name == "Conntrack Exhaustion" {
+		t.Fatalf("generic drops misattributed to conntrack exhaustion: %q", pat.Narrative)
+	}
+}

--- a/engine/rca_reclaim_gate_test.go
+++ b/engine/rca_reclaim_gate_test.go
@@ -1,0 +1,43 @@
+//go:build linux
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/ftahirops/xtop/model"
+)
+
+// TestReclaimGatedByPSI reproduces the reclaim-without-PSI misfire: direct
+// reclaim without any memory PSI is normal cache pressure, not a "reclaim
+// storm". The PSI dampener previously only lowered CONFIDENCE, but the matcher
+// keys off STRENGTH — so Direct Reclaim Storm could fire with PSI=0. The
+// reclaim evidence must not fire (strength 0) when PSI is absent, and must fire
+// when PSI confirms real pressure.
+func TestReclaimGatedByPSI(t *testing.T) {
+	mk := func(psiSomeAvg10 float64) model.RCAEntry {
+		curr := &model.Snapshot{}
+		curr.Global.Memory.Total = 16 * 1024 * 1024 * 1024
+		curr.Global.Memory.Available = 8 * 1024 * 1024 * 1024
+		curr.Global.PSI.Memory.Some.Avg10 = psiSomeAvg10
+		rates := &model.RateSnapshot{DirectReclaimRate: 1000} // well above warn
+		return analyzeMemory(nil, curr, rates, systemProfile{}, effectiveRCAThresholds{})
+	}
+	strengthOf := func(r model.RCAEntry) float64 {
+		for _, ev := range r.EvidenceV2 {
+			if ev.ID == "mem.reclaim.direct" {
+				return ev.Strength
+			}
+		}
+		return -1
+	}
+
+	// No PSI: reclaim must not fire.
+	if s := strengthOf(mk(0)); s > 0 {
+		t.Fatalf("direct reclaim fired with no PSI (strength=%v) — gated on confidence not strength", s)
+	}
+	// Real PSI pressure: reclaim should fire.
+	if s := strengthOf(mk(50)); s <= 0 {
+		t.Fatalf("direct reclaim did not fire under real PSI pressure (strength=%v)", s)
+	}
+}

--- a/engine/rca_runqueue_test.go
+++ b/engine/rca_runqueue_test.go
@@ -1,0 +1,53 @@
+//go:build linux
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/ftahirops/xtop/model"
+)
+
+// TestRunQueueUsesInstantaneousRunnable reproduces SEED-B: run-queue saturation
+// must be measured from instantaneous runnable tasks (procs_running), not the
+// Load1 EWMA. The xgen1 screen showed 13 runnable on 6 cores (ratio 2.17,
+// saturated) while Load1 was only 3.2 (ratio 0.53), so the cpu.runqueue
+// evidence never fired and the correct oversubscription narrative was starved.
+func TestRunQueueUsesInstantaneousRunnable(t *testing.T) {
+	curr := &model.Snapshot{}
+	curr.Global.CPU.NumCPUs = 6
+	curr.Global.CPU.LoadAvg = model.LoadAvg{Load1: 3.2, Running: 13, Total: 220}
+
+	entry := analyzeCPU(nil, curr, &model.RateSnapshot{}, systemProfile{}, effectiveRCAThresholds{})
+
+	var strength float64
+	found := false
+	for _, ev := range entry.EvidenceV2 {
+		if ev.ID == "cpu.runqueue" {
+			strength = ev.Strength
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("no cpu.runqueue evidence emitted")
+	}
+	if strength <= 0 {
+		t.Fatalf("cpu.runqueue did not fire for 13 runnable/6 cores (strength=%v); "+
+			"still using Load1-based ratio instead of procs_running", strength)
+	}
+}
+
+// TestRunQueueQuietDoesNotFire guards the low end: 2 runnable on 8 cores is not
+// saturation and must not fire.
+func TestRunQueueQuietDoesNotFire(t *testing.T) {
+	curr := &model.Snapshot{}
+	curr.Global.CPU.NumCPUs = 8
+	curr.Global.CPU.LoadAvg = model.LoadAvg{Load1: 1.5, Running: 2, Total: 300}
+
+	entry := analyzeCPU(nil, curr, &model.RateSnapshot{}, systemProfile{}, effectiveRCAThresholds{})
+	for _, ev := range entry.EvidenceV2 {
+		if ev.ID == "cpu.runqueue" && ev.Strength > 0 {
+			t.Fatalf("cpu.runqueue wrongly fired for 2 runnable/8 cores (strength=%v)", ev.Strength)
+		}
+	}
+}

--- a/engine/rca_score_bonus_test.go
+++ b/engine/rca_score_bonus_test.go
@@ -1,0 +1,52 @@
+//go:build linux
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/ftahirops/xtop/model"
+)
+
+// TestApplyScoreBonus pins the ordering fix: a domain bonus (steal, drops) must
+// be applied AFTER the score floor and only to a score that already cleared it,
+// so a sub-threshold domain can't be resurrected into a bottleneck by the bonus.
+func TestApplyScoreBonus(t *testing.T) {
+	cases := []struct {
+		name              string
+		score, bonus, floor int
+		gate              bool
+		want              int
+	}{
+		{"below floor cannot be resurrected by bonus", 15, 10, 20, true, 0},
+		{"below floor, no gate", 15, 10, 20, false, 0},
+		{"above floor augmented when gated", 25, 10, 20, true, 35},
+		{"above floor untouched when not gated", 25, 10, 20, false, 25},
+		{"zero score stays zero", 0, 10, 1, true, 0},
+		{"cap at 100", 98, 10, 20, true, 100},
+	}
+	for _, tc := range cases {
+		got := applyScoreBonus(tc.score, tc.bonus, tc.floor, tc.gate)
+		if got != tc.want {
+			t.Errorf("%s: applyScoreBonus(%d,%d,%d,%v)=%d want %d",
+				tc.name, tc.score, tc.bonus, tc.floor, tc.gate, got, tc.want)
+		}
+	}
+}
+
+// TestEvidenceFired covers the gate helper.
+func TestEvidenceFired(t *testing.T) {
+	evs := []model.Evidence{
+		{ID: "cpu.steal", Strength: 0.0},
+		{ID: "cpu.busy", Strength: 0.9},
+	}
+	if evidenceFired(evs, "cpu.steal") {
+		t.Error("cpu.steal has strength 0 — must not count as fired")
+	}
+	if !evidenceFired(evs, "cpu.busy") {
+		t.Error("cpu.busy has strength 0.9 — must count as fired")
+	}
+	if evidenceFired(evs, "cpu.missing") {
+		t.Error("absent evidence must not count as fired")
+	}
+}

--- a/engine/rca_swap_attribution_test.go
+++ b/engine/rca_swap_attribution_test.go
@@ -1,0 +1,92 @@
+//go:build linux
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/ftahirops/xtop/model"
+)
+
+// firedResult builds an AnalysisResult whose fired evidence is exactly the given
+// IDs at full strength, so MatchPattern / collectFiredEvidence see them.
+func firedResult(ids ...string) *model.AnalysisResult {
+	evs := make([]model.Evidence, 0, len(ids))
+	for _, id := range ids {
+		evs = append(evs, model.Evidence{ID: id, Strength: 1.0})
+	}
+	return &model.AnalysisResult{
+		RCA: []model.RCAEntry{{Bottleneck: "io", Score: 80, EvidenceV2: evs}},
+	}
+}
+
+// TestPureDiskIONotSwapStorm reproduces the CRITICAL misattribution: pure disk IO
+// (io.psi + io.disk.latency fire, NO swap) must not be labeled "swap thrashing".
+// The phantom mem.swap.activity evidence + MinMatch:2 let the two generic IO
+// signals alone satisfy the P90 "Memory-Induced IO Storm" pattern.
+func TestPureDiskIONotSwapStorm(t *testing.T) {
+	res := firedResult("io.psi", "io.disk.latency") // no swap activity at all
+	pat := MatchPattern(res)
+	if pat != nil && pat.Name == "Memory-Induced IO Storm" {
+		t.Fatalf("pure disk IO misattributed to swap: matched %q -> %q", pat.Name, pat.Narrative)
+	}
+}
+
+// TestNarrativeNoSwapNotViaSwap reproduces the narrative-template twin: memory PSI +
+// disk latency with NO swap must not produce a "...via swap" narrative.
+func TestNarrativeNoSwapNotViaSwap(t *testing.T) {
+	fired := map[string]model.Evidence{
+		"mem.psi":          {ID: "mem.psi", Strength: 1.0},
+		"io.disk.latency":  {ID: "io.disk.latency", Strength: 1.0},
+	}
+	got := matchNarrativeTemplate(fired)
+	if got == "Memory pressure cascading into IO latency via swap" {
+		t.Fatalf("no-swap scenario produced a 'via swap' narrative: %q", got)
+	}
+}
+
+// TestRealSwapMatchesIOStorm guards the correct case: with genuine swap activity
+// plus IO pressure, the swap-thrashing pattern SHOULD fire.
+func TestRealSwapMatchesIOStorm(t *testing.T) {
+	res := firedResult("mem.swap.activity", "io.psi", "io.disk.latency")
+	pat := MatchPattern(res)
+	if pat == nil || pat.Name != "Memory-Induced IO Storm" {
+		got := "nil"
+		if pat != nil {
+			got = pat.Name
+		}
+		t.Fatalf("real swap+IO should match Memory-Induced IO Storm, got %s", got)
+	}
+}
+
+// TestSwapActivityEvidenceEmitted proves the emitter fix: when swap is active the
+// memory analysis must emit a fired mem.swap.activity evidence (the ID the whole
+// pattern/narrative/causal layer consumes); when idle it must not fire.
+func TestSwapActivityEvidenceEmitted(t *testing.T) {
+	mkSnap := func() *model.Snapshot {
+		s := &model.Snapshot{}
+		s.Global.Memory.Total = 16 * 1024 * 1024 * 1024
+		s.Global.Memory.Available = 8 * 1024 * 1024 * 1024
+		return s
+	}
+	strengthOf := func(r model.RCAEntry, id string) (float64, bool) {
+		for _, ev := range r.EvidenceV2 {
+			if ev.ID == id {
+				return ev.Strength, true
+			}
+		}
+		return 0, false
+	}
+
+	// Active swap: 25 MB/s in + 5 MB/s out — well above the warn threshold.
+	active := analyzeMemory(nil, mkSnap(), &model.RateSnapshot{SwapInRate: 25, SwapOutRate: 5}, systemProfile{}, effectiveRCAThresholds{})
+	if s, ok := strengthOf(active, "mem.swap.activity"); !ok || s <= 0 {
+		t.Fatalf("active swap did not emit a fired mem.swap.activity (ok=%v strength=%v)", ok, s)
+	}
+
+	// Idle: no swap — mem.swap.activity must not fire.
+	idle := analyzeMemory(nil, mkSnap(), &model.RateSnapshot{}, systemProfile{}, effectiveRCAThresholds{})
+	if s, ok := strengthOf(idle, "mem.swap.activity"); ok && s > 0 {
+		t.Fatalf("idle host wrongly fired mem.swap.activity at strength %v", s)
+	}
+}

--- a/engine/rca_verified_label_test.go
+++ b/engine/rca_verified_label_test.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/ftahirops/xtop/model"
+)
+
+// TestIsVerifiedTier pins the policy behind readiness-review Finding #4 (verifier
+// is additive + label unverified): only Tier A/B count as verified; Tier C
+// (probable) and D (inconclusive/abstain) must be labeled unverified.
+func TestIsVerifiedTier(t *testing.T) {
+	verified := []model.VerificationTier{model.TierAConfirmed, model.TierBVerified}
+	unverified := []model.VerificationTier{model.TierCProbable, model.TierDInconclusive}
+
+	for _, tr := range verified {
+		if !isVerifiedTier(tr) {
+			t.Errorf("tier %v should count as verified", tr)
+		}
+	}
+	for _, tr := range unverified {
+		if isVerifiedTier(tr) {
+			t.Errorf("tier %v must NOT count as verified (label it)", tr)
+		}
+	}
+}

--- a/engine/scoring.go
+++ b/engine/scoring.go
@@ -114,18 +114,29 @@ func domainConfidence(evs []model.Evidence) float64 {
 		return 0
 	}
 
-	// Average confidence of fired evidence
-	var sumConf float64
+	// Average confidence + peak strength of fired evidence
+	var sumConf, maxStrength float64
 	var count int
 	for _, e := range evs {
 		if e.Strength >= 0.35 {
 			sumConf += e.Confidence
 			count++
+			if e.Strength > maxStrength {
+				maxStrength = e.Strength
+			}
 		}
 	}
 	avgConf := sumConf / float64(count)
 
 	conf := 0.3 + 0.2*float64(fired-1) + 0.5*avgConf
+	// Cap by peak signal strength: a domain whose strongest evidence is only
+	// marginally over threshold cannot be near-certain, no matter how many weak
+	// signals piled up or how measurable they were. Prevents 93%+ confidence on
+	// weak/misattributed causes (many barely-fired signals used to saturate the
+	// count term to 0.98).
+	if cap := 0.5 + 0.5*maxStrength; conf > cap {
+		conf = cap
+	}
 	if conf < 0 {
 		conf = 0
 	}

--- a/engine/scoring.go
+++ b/engine/scoring.go
@@ -17,6 +17,34 @@ var slotWeights = map[string]float64{
 // v2TrustGate returns true if evidence meets the v2 trust requirements:
 // 2+ groups with strength >= 0.35 AND at least 1 measured with confidence >= 0.8
 // AND evidence comes from at least 2 different weight categories (diversity check).
+// evidenceFired reports whether an evidence ID is present with non-zero strength.
+func evidenceFired(evs []model.Evidence, id string) bool {
+	for _, e := range evs {
+		if e.ID == id && e.Strength > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// applyScoreBonus applies a domain score bonus with correct ordering: the score
+// floor is applied FIRST, and the bonus only augments a score that already
+// cleared the floor. This prevents a sub-threshold domain from being resurrected
+// into a bottleneck purely by a bonus (e.g. a few % steal, or minor packet
+// drops). Result is capped at 100.
+func applyScoreBonus(score, bonus, floor int, gate bool) int {
+	if score < floor {
+		score = 0
+	}
+	if score > 0 && gate {
+		score += bonus
+	}
+	if score > 100 {
+		score = 100
+	}
+	return score
+}
+
 func v2TrustGate(evs []model.Evidence) bool {
 	groups := evidenceGroupsFired(evs, 0.35)
 	if groups < 2 {

--- a/model/snapshot.go
+++ b/model/snapshot.go
@@ -248,9 +248,20 @@ type CollectionHealth struct {
 }
 
 // AnalysisResult is the full output of one analysis cycle.
+// CoverageInfo describes the signal coverage behind an AnalysisResult.
+type CoverageInfo struct {
+	Mode           string   `json:"mode"`                      // "full" | "lean"
+	OmittedSignals []string `json:"omitted_signals,omitempty"` // collectors not run in this mode
+}
+
 type AnalysisResult struct {
 	Health     HealthLevel
 	Confidence int // 0-100
+
+	// Coverage reports which collector mode produced this analysis and which
+	// signal classes were not observable (e.g. lean/fleet mode omits several
+	// collectors). Lets consumers avoid over-reading a reduced-signal verdict.
+	Coverage CoverageInfo `json:"coverage,omitempty"`
 
 	// Facts is the typed-evidence layer (NEXTGEN Phase 2). Each entry
 	// is a single observation with full provenance — see Fact in

--- a/model/snapshot.go
+++ b/model/snapshot.go
@@ -263,6 +263,12 @@ type AnalysisResult struct {
 	// collectors). Lets consumers avoid over-reading a reduced-signal verdict.
 	Coverage CoverageInfo `json:"coverage,omitempty"`
 
+	// PrimaryVerified is true when the formal verifier confirmed the primary
+	// bottleneck's cause (Tier A/B). The verifier is additive — Health is still
+	// score-driven — so when this is false on a degraded/critical result, the
+	// UI/API should label the verdict "unverified".
+	PrimaryVerified bool `json:"primary_verified"`
+
 	// Facts is the typed-evidence layer (NEXTGEN Phase 2). Each entry
 	// is a single observation with full provenance — see Fact in
 	// model/fact.go. Phase 2 emits these in parallel to the legacy

--- a/model/snapshot.go
+++ b/model/snapshot.go
@@ -372,6 +372,11 @@ type AnalysisResult struct {
 	// Narrative engine output
 	Narrative *Narrative
 
+	// ConfigDriftSuggestions holds "SUGGESTED: ..." remediation lines produced
+	// by config-drift correlation, which runs before the narrative is built.
+	// They are appended to Narrative.Evidence after BuildNarrative. Transient.
+	ConfigDriftSuggestions []string `json:"-"`
+
 	// Temporal causality chain
 	TemporalChain *TemporalChain
 

--- a/ui/app.go
+++ b/ui/app.go
@@ -1392,15 +1392,19 @@ func (m Model) View() string {
 	// Sticky RCA: use pinned result for RCA-heavy views (overview, beginner, explain)
 	// Live metrics on detail pages always use current m.result
 	rcaResult, resolvedAgo := m.displayResult()
+	// Render the overview as one consistent frame: when rcaResult is pinned, use
+	// the snapshot/rates captured with it so live metrics don't contradict the
+	// pinned analysis.
+	dispSnap, dispRates := m.displayFrame()
 
 	var content string
 	// Beginner mode: render simplified page on overview
 	if m.beginnerMode && m.page == PageOverview {
-		content = renderBeginnerPage(m.snap, m.rates, rcaResult, resolvedAgo, renderW, m.height)
+		content = renderBeginnerPage(dispSnap, dispRates, rcaResult, resolvedAgo, renderW, m.height)
 	} else {
 		switch m.page {
 		case PageOverview:
-			content = renderOverview(m.snap, m.rates, rcaResult, m.engine.History, smartDisks, m.probeManager, m.layoutMode, m.overviewCompact, renderW, m.height, m.intermediateMode)
+			content = renderOverview(dispSnap, dispRates, rcaResult, m.engine.History, smartDisks, m.probeManager, m.layoutMode, m.overviewCompact, renderW, m.height, m.intermediateMode)
 		case PageCPU:
 			content = renderCPUPage(m.snap, m.rates, m.result, m.probeManager, renderW, m.height, m.intermediateMode)
 		case PageMemory:
@@ -2056,6 +2060,9 @@ func (m *Model) updatePinnedRCA() {
 			shouldPin = true
 		} else if m.result.PrimaryScore > m.pinnedResult.PrimaryScore {
 			shouldPin = true // new finding is worse
+		} else if m.result.PrimaryBottleneck != m.pinnedResult.PrimaryBottleneck {
+			shouldPin = true // a DIFFERENT cause is now primary — don't let the
+			// stale pin mask it just because its score isn't strictly higher
 		} else if !m.resolvedAt.IsZero() && now.Sub(m.resolvedAt) > 15*time.Second {
 			shouldPin = true // old pin is in decay phase, replace with fresh finding
 		}
@@ -2223,6 +2230,18 @@ func (m *Model) displayResult() (result *model.AnalysisResult, resolvedAgo int) 
 		m.result.PinnedResolvedSec = 0
 	}
 	return m.result, 0
+}
+
+// displayFrame returns the snapshot and rates that match displayResult(), so the
+// overview renders one internally-consistent frame. When a pinned result is
+// shown, its captured snapshot/rates are used instead of the live ones —
+// otherwise live panels (e.g. CPU busy%) contradict the pinned analysis and its
+// derived Capacity/evidence in the same frame.
+func (m *Model) displayFrame() (*model.Snapshot, *model.RateSnapshot) {
+	if m.pinnedResult != nil && m.pinnedSnap != nil {
+		return m.pinnedSnap, m.pinnedRates
+	}
+	return m.snap, m.rates
 }
 
 // updatePinnedNetSummary pins the network intelligence summary during degraded/critical conditions.

--- a/ui/app_pin_test.go
+++ b/ui/app_pin_test.go
@@ -1,0 +1,43 @@
+//go:build linux
+
+package ui
+
+import (
+	"testing"
+
+	"github.com/ftahirops/xtop/model"
+)
+
+// TestDisplayFrameUsesPinned: when a pinned result is shown, the panels must use
+// the snapshot/rates captured WITH that result, not live ones — otherwise live
+// metrics (e.g. CPU 30.9%) render next to a pinned analysis (93%), contradicting
+// each other in one frame.
+func TestDisplayFrameUsesPinned(t *testing.T) {
+	live, liveR := &model.Snapshot{}, &model.RateSnapshot{}
+	pinS, pinR := &model.Snapshot{}, &model.RateSnapshot{}
+
+	m := &Model{snap: live, rates: liveR,
+		pinnedResult: &model.AnalysisResult{}, pinnedSnap: pinS, pinnedRates: pinR}
+	if s, r := m.displayFrame(); s != pinS || r != pinR {
+		t.Fatal("pinned frame not used when result is pinned")
+	}
+
+	m2 := &Model{snap: live, rates: liveR}
+	if s, r := m2.displayFrame(); s != live || r != liveR {
+		t.Fatal("live frame not used when nothing is pinned")
+	}
+}
+
+// TestRepinOnCauseChange: a different current bottleneck must replace the pin
+// even if its score isn't strictly higher, so a stale pin can't mask a new cause.
+func TestRepinOnCauseChange(t *testing.T) {
+	m := &Model{
+		pinnedResult: &model.AnalysisResult{PrimaryBottleneck: "io", PrimaryScore: 30, Health: model.HealthDegraded},
+		result:       &model.AnalysisResult{PrimaryBottleneck: "cpu", PrimaryScore: 28, Health: model.HealthDegraded},
+		snap:         &model.Snapshot{}, rates: &model.RateSnapshot{},
+	}
+	m.updatePinnedRCA()
+	if m.pinnedResult.PrimaryBottleneck != "cpu" {
+		t.Fatalf("pin did not update to the new cause; still %q", m.pinnedResult.PrimaryBottleneck)
+	}
+}

--- a/ui/overview_blocks.go
+++ b/ui/overview_blocks.go
@@ -280,7 +280,13 @@ func renderRCABox(result *model.AnalysisResult, width int) string {
 
 		// --- WHAT: short bottleneck name only ---
 		whatStr := result.PrimaryBottleneck
-		sb.WriteString(boxRow(dimStyle.Render("WHAT:  ")+sevStyle.Render(truncate(whatStr, maxField)), innerW) + "\n")
+		whatLine := dimStyle.Render("WHAT:  ") + sevStyle.Render(truncate(whatStr, maxField))
+		// Additive verifier: label a degraded/critical verdict the formal
+		// verifier did not confirm (Finding #4: additive + label unverified).
+		if result.Health >= model.HealthDegraded && !result.PrimaryVerified {
+			whatLine += " " + dimStyle.Render("(unverified)")
+		}
+		sb.WriteString(boxRow(whatLine, innerW) + "\n")
 
 		// --- WHY: narrative root cause (human explanation, not raw metrics) ---
 		why := ""


### PR DESCRIPTION
## Summary

RCA engine correctness overhaul. Two workstreams, each finding reproduced as a failing test first, then fixed at the root:

1. **Attribution audit** (`RCA_ENGINE_AUDIT.md`) — 27 adversarially-verified findings collapsing into **7 structural classes**, all closed.
2. **Production-readiness review** (`RCA_PRODUCTION_READINESS_REVIEW.md`) — **5 of 7** findings fixed (contained ones); #2/#3 pipeline-ordering refactor tracked separately.

Motivated by a live `xgen1` (Proxmox/KVM) screen that reported "hypervisor stealing CPU time" at 1.1% steal, "swap thrashing" with no swap, CPU 30.9% next to 93%, and 93% confidence on the wrong cause.

## Attribution classes fixed

- **Class 1 — specific narrative without defining evidence** (~9 sites). CRITICAL: `mem.swap.activity` was consumed everywhere but never emitted, so two generic IO signals fired "swap thrashing" at priority 90 on non-swapping hosts. Emit it + mark defining evidence `Required` across VM/IO/network patterns.
- **Class 7 — wrong source / ordering.** Run-queue used `Load1/nCPUs` instead of instantaneous `procs_running`; steal pattern ranked below oversubscription; conntrack keyed on generic drops.
- **Class 3 — unit bugs.** `io.writeback` compared bytes to MB thresholds (always fired); fs-full dampener compared free% to a used% constant (dead code).
- **Class 2 — bonuses without gating signal.** Steal/drops bonuses applied before the score floor and gated on generic trust; reclaim dampened confidence but not strength.
- **Class 5 — confidence decoupled from strength.** Capped by peak evidence strength (the 93%).
- **Class 4 — WHO vs WHY.** Slab leak blamed userspace; steal blame threshold diverged from the narrative; IO culprit misattributed on trace swap.
- **Class 6 — live vs pinned rendering.** Pinned snapshot/rates were captured but never used at render (the 30.9%-vs-93% split); re-pin on cause change.

## Readiness findings fixed

- **#1** Proxmox VM memory evidence now emitted before scoring (was appended after, couldn't affect the verdict).
- **#7** removed dead duplicate OOM score-floor.
- **#5** PSI fact durations stamped despite `.avg10` id suffix mismatch.
- **#6** lean/fleet coverage surfaced (`AnalysisResult.Coverage`).
- **#4** unverified verdicts labeled `(unverified)` — verifier stays additive.

## Not in this PR

- **#2 / #3** (config-drift + journal Tier-1 injected after finalization) — an architectural single-pass-pipeline reorder, to be done as a dedicated follow-up (approach: move injections before finalization).

## Verification

- `go test ./...` → **926 passed / 0 failed** (27 packages)
- `go vet ./...` clean; `CGO_ENABLED=0 go build ./...` clean (both `xtop` and `xtop-agent`)
- Every fix TDD'd (RED verified before GREEN); 11 new test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added coverage metadata (full vs lean), omitted-signal reporting, and config-drift remediation hints to RCA results.
  - Added “unverified” labeling for primary findings in degraded states.
  - Improved attribution to better reflect memory, swap, CPU-steal, VM, network, and IO drivers.
- **Bug Fixes**
  - Corrected IO writeback units, filesystem confidence damping, and memory/IO swap attribution thresholds.
  - Tightened narrative/pattern matching to require the right defining evidence and improved pipeline timing for scoring/narratives.
  - Enhanced pinned RCA behavior when the primary bottleneck changes.
- **Documentation**
  - Added a comprehensive “Correctness Audit” for RCA verification and systemic recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->