### PR TITLE
feat(disk): du-style TOP DIRECTORIES rollup in DiskGuard

### DIFF
--- a/collector/bigfiles.go
+++ b/collector/bigfiles.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -21,9 +22,17 @@ type BigFileCollector struct {
 
 	mu        sync.Mutex
 	cache     []model.BigFile
+	cacheDirs []model.BigDir
 	lastScan  time.Time
 	triggered bool // set externally when disk pressure detected
 	firstRun  bool // true = skip expensive scan on first tick; set false after first Collect
+}
+
+// dirAgg accumulates a directory subtree's recursive total during the walk.
+type dirAgg struct {
+	bytes uint64
+	files int
+	depth int
 }
 
 func (b *BigFileCollector) Name() string { return "bigfiles" }
@@ -61,6 +70,7 @@ func (b *BigFileCollector) Collect(snap *model.Snapshot) error {
 		b.firstRun = false
 		b.mu.Unlock()
 		snap.Global.BigFiles = b.cache
+		snap.Global.BigDirs = b.cacheDirs
 		return nil
 	}
 	b.mu.Unlock()
@@ -69,6 +79,7 @@ func (b *BigFileCollector) Collect(snap *model.Snapshot) error {
 		// Return cached results
 		b.mu.Lock()
 		snap.Global.BigFiles = b.cache
+		snap.Global.BigDirs = b.cacheDirs
 		b.mu.Unlock()
 		return nil
 	}
@@ -83,13 +94,14 @@ func (b *BigFileCollector) Collect(snap *model.Snapshot) error {
 	}
 
 	var files []model.BigFile
+	dirs := make(map[string]*dirAgg)
 	budget := 3000 // max stat() calls per scan
 
 	for _, dir := range scanDirs {
 		if budget <= 0 {
 			break
 		}
-		budget = walkDir(dir, minSize, &files, budget, 0)
+		budget, _, _ = walkDir(dir, minSize, &files, dirs, budget, 0)
 	}
 
 	// Sort by size descending
@@ -101,26 +113,82 @@ func (b *BigFileCollector) Collect(snap *model.Snapshot) error {
 		files = files[:maxFiles]
 	}
 
+	// Roll the per-directory totals up into the top disjoint subtrees.
+	bigDirs := topDirs(dirs, minSize, maxFiles)
+
 	// Update cache
 	b.mu.Lock()
 	b.cache = files
+	b.cacheDirs = bigDirs
 	b.lastScan = time.Now()
 	b.mu.Unlock()
 
 	snap.Global.BigFiles = files
+	snap.Global.BigDirs = bigDirs
 	return nil
 }
 
-// walkDir walks a directory tree collecting large files, with a depth limit and budget.
-func walkDir(dir string, minSize uint64, files *[]model.BigFile, budget int, depth int) int {
+// topDirs selects the largest non-nested directory subtrees from the walk.
+// Candidates below the scan roots (depth >= 1) that meet minSize are ranked by
+// recursive size; a directory is skipped if an already-selected directory is
+// one of its ancestors, so the result lists disjoint hot spots (e.g. show
+// /var/lib/docker/volumes rather than both it and its parent).
+func topDirs(dirs map[string]*dirAgg, minSize uint64, max int) []model.BigDir {
+	type cand struct {
+		path string
+		agg  *dirAgg
+	}
+	cands := make([]cand, 0, len(dirs))
+	for p, a := range dirs {
+		if a.depth >= 1 && a.bytes >= minSize {
+			cands = append(cands, cand{p, a})
+		}
+	}
+	sort.Slice(cands, func(i, j int) bool {
+		return cands[i].agg.bytes > cands[j].agg.bytes
+	})
+
+	var out []model.BigDir
+	var picked []string
+	for _, c := range cands {
+		if len(out) >= max {
+			break
+		}
+		nested := false
+		for _, p := range picked {
+			if strings.HasPrefix(c.path, p+"/") {
+				nested = true
+				break
+			}
+		}
+		if nested {
+			continue
+		}
+		picked = append(picked, c.path)
+		out = append(out, model.BigDir{
+			Path:      c.path,
+			SizeBytes: c.agg.bytes,
+			FileCount: c.agg.files,
+		})
+	}
+	return out
+}
+
+// walkDir walks a directory tree collecting large files, with a depth limit and
+// budget. It also records each directory's recursive size into dirs (du-style)
+// and returns the remaining budget plus this subtree's total bytes and file count.
+func walkDir(dir string, minSize uint64, files *[]model.BigFile, dirs map[string]*dirAgg, budget, depth int) (int, uint64, int) {
 	if budget <= 0 || depth > 5 {
-		return budget
+		return budget, 0, 0
 	}
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return budget
+		return budget, 0, 0
 	}
+
+	var subtreeBytes uint64
+	var subtreeFiles int
 
 	for _, e := range entries {
 		if budget <= 0 {
@@ -143,7 +211,11 @@ func walkDir(dir string, minSize uint64, files *[]model.BigFile, budget int, dep
 			case "/var/lib/docker/overlay2", "/var/lib/containerd":
 				continue
 			}
-			budget = walkDir(fullPath, minSize, files, budget, depth+1)
+			var childBytes uint64
+			var childFiles int
+			budget, childBytes, childFiles = walkDir(fullPath, minSize, files, dirs, budget, depth+1)
+			subtreeBytes += childBytes
+			subtreeFiles += childFiles
 			continue
 		}
 
@@ -155,6 +227,8 @@ func walkDir(dir string, minSize uint64, files *[]model.BigFile, budget int, dep
 		}
 
 		size := uint64(info.Size())
+		subtreeBytes += size
+		subtreeFiles++
 		if size >= minSize {
 			*files = append(*files, model.BigFile{
 				Path:      fullPath,
@@ -165,5 +239,6 @@ func walkDir(dir string, minSize uint64, files *[]model.BigFile, budget int, dep
 		}
 	}
 
-	return budget
+	dirs[dir] = &dirAgg{bytes: subtreeBytes, files: subtreeFiles, depth: depth}
+	return budget, subtreeBytes, subtreeFiles
 }

--- a/collector/bigfiles_test.go
+++ b/collector/bigfiles_test.go
@@ -1,0 +1,95 @@
+//go:build linux
+
+package collector
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ftahirops/xtop/model"
+)
+
+// TestWalkDirAggregatesDirectories verifies that walkDir rolls up recursive
+// subtree sizes and file counts into the dirs map.
+func TestWalkDirAggregatesDirectories(t *testing.T) {
+	root := t.TempDir()
+	// root/a has two files totalling 300 bytes across a nested dir.
+	writeFile(t, filepath.Join(root, "a", "f1"), 100)
+	writeFile(t, filepath.Join(root, "a", "deep", "f2"), 200)
+	// root/b has one file of 50 bytes.
+	writeFile(t, filepath.Join(root, "b", "f3"), 50)
+
+	var files []model.BigFile
+	dirs := make(map[string]*dirAgg)
+	budget, total, count := walkDir(root, 0, &files, dirs, 3000, 0)
+
+	if budget >= 3000 {
+		t.Errorf("expected budget to be consumed, got %d", budget)
+	}
+	if total != 350 {
+		t.Errorf("root subtree bytes = %d, want 350", total)
+	}
+	if count != 3 {
+		t.Errorf("root subtree files = %d, want 3", count)
+	}
+
+	a := dirs[filepath.Join(root, "a")]
+	if a == nil || a.bytes != 300 || a.files != 2 {
+		t.Errorf("dir a agg = %+v, want bytes=300 files=2", a)
+	}
+	if a.depth != 1 {
+		t.Errorf("dir a depth = %d, want 1", a.depth)
+	}
+	b := dirs[filepath.Join(root, "b")]
+	if b == nil || b.bytes != 50 || b.files != 1 {
+		t.Errorf("dir b agg = %+v, want bytes=50 files=1", b)
+	}
+}
+
+// TestTopDirsDisjoint verifies that topDirs skips directories nested under an
+// already-selected ancestor and excludes the scan roots (depth 0).
+func TestTopDirsDisjoint(t *testing.T) {
+	dirs := map[string]*dirAgg{
+		"/var/lib":               {bytes: 1000, files: 10, depth: 0}, // root, must be excluded
+		"/var/lib/docker":        {bytes: 900, files: 9, depth: 1},   // biggest disjoint
+		"/var/lib/docker/volume": {bytes: 800, files: 5, depth: 2},   // nested under docker -> skip
+		"/var/lib/mysql":         {bytes: 400, files: 3, depth: 1},   // separate -> include
+		"/var/lib/small":         {bytes: 10, files: 1, depth: 1},    // below minSize -> skip
+	}
+
+	out := topDirs(dirs, 50, 10)
+
+	if len(out) != 2 {
+		t.Fatalf("got %d dirs, want 2: %+v", len(out), out)
+	}
+	if out[0].Path != "/var/lib/docker" || out[0].SizeBytes != 900 {
+		t.Errorf("first = %+v, want /var/lib/docker 900", out[0])
+	}
+	if out[1].Path != "/var/lib/mysql" || out[1].SizeBytes != 400 {
+		t.Errorf("second = %+v, want /var/lib/mysql 400", out[1])
+	}
+	for _, d := range out {
+		if d.Path == "/var/lib" {
+			t.Error("scan root /var/lib should be excluded")
+		}
+		if d.Path == "/var/lib/docker/volume" {
+			t.Error("nested /var/lib/docker/volume should be collapsed into parent")
+		}
+	}
+}
+
+// TestTopDirsRespectsMax verifies the result count is capped.
+func TestTopDirsRespectsMax(t *testing.T) {
+	dirs := map[string]*dirAgg{
+		"/x/a": {bytes: 500, files: 1, depth: 1},
+		"/x/b": {bytes: 400, files: 1, depth: 1},
+		"/x/c": {bytes: 300, files: 1, depth: 1},
+	}
+	out := topDirs(dirs, 50, 2)
+	if len(out) != 2 {
+		t.Fatalf("got %d dirs, want 2 (capped)", len(out))
+	}
+	if out[0].SizeBytes != 500 || out[1].SizeBytes != 400 {
+		t.Errorf("expected largest two by size, got %+v", out)
+	}
+}

--- a/model/metrics.go
+++ b/model/metrics.go
@@ -201,6 +201,15 @@ type BigFile struct {
 	ModTime   int64 // unix timestamp
 }
 
+// BigDir represents a directory subtree consuming significant disk space.
+// SizeBytes is the recursive total of files walked beneath Path (du-style),
+// bounded by the scanner's stat budget — i.e. a lower bound, not exact du(1).
+type BigDir struct {
+	Path      string
+	SizeBytes uint64
+	FileCount int // number of regular files counted in the subtree
+}
+
 // DeletedOpenFile represents a file that was deleted but is still held open.
 type DeletedOpenFile struct {
 	PID       int
@@ -897,6 +906,7 @@ type GlobalMetrics struct {
 	Mounts           []MountStats
 	DeletedOpen    []DeletedOpenFile
 	BigFiles       []BigFile
+	BigDirs        []BigDir
 	FilelessProcs  []FilelessProcess
 	Security       SecurityMetrics
 	Logs           LogMetrics

--- a/ui/page_diskguard.go
+++ b/ui/page_diskguard.go
@@ -300,6 +300,39 @@ func renderDiskGuardPage(snap *model.Snapshot, rates *model.RateSnapshot, result
 	}
 	sb.WriteString(boxSection("BIGGEST FILES", bigLines, iw))
 
+	// Section 3b: TOP DIRECTORIES (du-style recursive rollup of the walk)
+	var dirLines []string
+	dirHdr := fmt.Sprintf("%s %s %s",
+		styledPad(dimStyle.Render("SIZE"), 10),
+		styledPad(dimStyle.Render("FILES"), 10),
+		dimStyle.Render("DIRECTORY"))
+	dirLines = append(dirLines, dirHdr)
+
+	if snap != nil && len(snap.Global.BigDirs) > 0 {
+		shown := 0
+		for _, bd := range snap.Global.BigDirs {
+			if shown >= 6 {
+				break
+			}
+			sizeStr := fmtBytes(bd.SizeBytes)
+			if bd.SizeBytes > 1024*1024*1024 {
+				sizeStr = critStyle.Render(sizeStr)
+			} else if bd.SizeBytes > 100*1024*1024 {
+				sizeStr = warnStyle.Render(sizeStr)
+			}
+			filesStr := dimStyle.Render(fmt.Sprintf("%d", bd.FileCount))
+			line := fmt.Sprintf("%s %s %s",
+				styledPad(sizeStr, 10),
+				styledPad(filesStr, 10),
+				truncate(bd.Path, 80))
+			dirLines = append(dirLines, line)
+			shown++
+		}
+	} else {
+		dirLines = append(dirLines, dimStyle.Render("  no directories > 50MB in scanned paths"))
+	}
+	sb.WriteString(boxSection("TOP DIRECTORIES", dirLines, iw))
+
 	// Section 4: DELETED-BUT-OPEN FILES
 	var delLines []string
 	delHdr := fmt.Sprintf("%s %s %s %s",


### PR DESCRIPTION
## Summary
Adds a **du-style "TOP DIRECTORIES" rollup** to the DiskGuard page. The disk view showed the biggest individual *files* but never which *directory* was eating space — a directory full of medium files never surfaced.

The existing `BigFile` walker already visits every entry, so per-directory recursive totals are accumulated in the same pass (near-zero extra cost, same stat budget / depth cap).

## Changes
- `model.BigDir {Path, SizeBytes, FileCount}` + `Global.BigDirs`
- `collector/bigfiles.go`: `walkDir` returns subtree bytes/files and records each directory; `topDirs()` selects the largest **disjoint** subtrees (collapses nested dirs, excludes scan roots)
- `ui/page_diskguard.go`: new **TOP DIRECTORIES** section (SIZE / FILES / DIRECTORY)
- Tests: subtree aggregation, disjoint selection + root exclusion, result cap

## Notes
- Sizes are a **budget-bounded lower bound** (documented on `BigDir`) — apparent size, not hardlink/sparse-aware.
- The persistent, live, hardlink-aware index (the **dux SQLite sidecar, Phase 2**) is future work.
- Independent of the RCA correctness PR (#9).

## Verification
`CGO_ENABLED=0 go build ./...` clean, `go vet ./...` clean, `go test ./...` → 897 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added disk usage insights for the largest directories, including recursive size and file counts.
  - Displayed top directories in the DiskGuard page with size-based highlighting and truncated paths.
  - Added a placeholder when no directory data is available.

- **Bug Fixes**
  - Preserved directory results when displaying cached scan data.

- **Tests**
  - Added coverage for directory size aggregation, ranking, nesting, and result limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->