### PR TITLE
fix: vhost-only probe false-CRIT + explain apps Ranks column

### DIFF
--- a/collector/healthcheck.go
+++ b/collector/healthcheck.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sync"
@@ -220,8 +221,18 @@ func probeHTTP(t probeTarget) model.HealthProbeResult {
 	r.LatencyMs = float64(time.Since(start).Microseconds()) / 1000
 
 	if err != nil {
-		r.Status = "CRIT"
-		r.Detail = truncateStr(err.Error(), 60)
+		// Distinguish "service down" from "up but no HTTP response". A vhost-only
+		// server (e.g. nginx `return 444` for requests with no matching Host/SNI)
+		// accepts the TCP connection then closes it with no reply — the probe hits
+		// bare 127.0.0.1 with no Host header. That is NOT an outage, so only CRIT
+		// when the port itself refuses/does not accept a connection.
+		if tcpPortOpen(t.target) {
+			r.Status = "WARN"
+			r.Detail = "port open, no HTTP response (vhost-only?)"
+		} else {
+			r.Status = "CRIT"
+			r.Detail = truncateStr(err.Error(), 60)
+		}
 		return r
 	}
 	defer resp.Body.Close()
@@ -357,6 +368,34 @@ func (h *HealthCheckCollector) scanCertFiles() {
 	}
 
 	h.cached = remaining
+}
+
+// tcpPortOpen reports whether the host:port behind an http(s) URL accepts a TCP
+// connection. Used to tell "service up but no HTTP reply" (e.g. nginx return 444
+// on a vhost-only host) apart from "service down" (connection refused/timeout).
+func tcpPortOpen(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	if host == "" {
+		return false
+	}
+	port := u.Port()
+	if port == "" {
+		if u.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), 2*time.Second)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
 }
 
 func truncateStr(s string, maxLen int) string {

--- a/collector/healthcheck_probe_test.go
+++ b/collector/healthcheck_probe_test.go
@@ -1,0 +1,51 @@
+//go:build linux
+
+package collector
+
+import (
+	"net"
+	"testing"
+)
+
+// TestProbeHTTPListeningButNoResponseNotCrit reproduces the false-CRIT bug: a
+// server that accepts the TCP connection but sends no HTTP response (e.g. nginx
+// `return 444` on a vhost-only server, which xtop probes as bare 127.0.0.1 with
+// no Host header) must NOT be reported as down/CRIT — the service is up.
+func TestProbeHTTPListeningButNoResponseNotCrit(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	// Accept every connection and immediately close it — no HTTP reply.
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			c.Close()
+		}
+	}()
+
+	r := probeHTTP(probeTarget{name: "t", probeType: "http", target: "http://" + ln.Addr().String() + "/"})
+	if r.Status == "CRIT" {
+		t.Fatalf("a listening port with no HTTP reply must not be CRIT (service is up); got CRIT: %q", r.Detail)
+	}
+}
+
+// TestProbeHTTPPortClosedIsCrit guards the real-down case: nothing listening →
+// connection refused → CRIT.
+func TestProbeHTTPPortClosedIsCrit(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	ln.Close() // free the port so a connect is refused
+
+	r := probeHTTP(probeTarget{name: "t", probeType: "http", target: "http://" + addr + "/"})
+	if r.Status != "CRIT" {
+		t.Fatalf("a genuinely down (refused) port must be CRIT; got %q (%s)", r.Status, r.Detail)
+	}
+}

--- a/ui/page_apps.go
+++ b/ui/page_apps.go
@@ -151,6 +151,8 @@ func renderAppsResourceShare(snap *model.Snapshot, iw int) string {
 	sb.WriteString("\n")
 	sb.WriteString(titleStyle.Render("RESOURCE SHARE"))
 	sb.WriteString(dimStyle.Render("   per-dimension rank · capacity share · headroom  (no composite % — each dim is independent)"))
+	sb.WriteString("\n")
+	sb.WriteString(dimStyle.Render("   Ranks:  C=CPU  M=Mem  I=IO  N=Net   ·   #n = this app's rank in that dimension (#1 = top consumer)   ·   — = not ranked"))
 	sb.WriteString("\n\n")
 
 	// Detect active bottleneck from the first app's Share.BottleneckDimension


### PR DESCRIPTION
## Summary
Two fixes to the Apps page, both from live findings on a multi-tenant nginx host:

### 1. `fix(collector)` — stop false-CRIT on vhost-only HTTP servers
`probeHTTP` marked **any** `http.Get` error as `CRIT`. On a name-based virtual-host server (nginx `return 444`, apache default vhost), a probe to bare `127.0.0.1:80/443` with no `Host` header is accepted then closed with no reply → `Get` returns `EOF` → a healthy nginx showed as **down**. This false-CRITs every vhost machine (verified live: `curl 127.0.0.1:80` → empty reply/000, but `curl -H 'Host: localhost'` → 200).

Fix: on `Get` error, do a TCP liveness dial. Port still accepts a connection → **WARN** "port open, no HTTP response (vhost-only?)"; only refused/timeout → **CRIT**. Tests: accept-then-close listener is not CRIT; closed port is CRIT.

### 2. `feat(ui)` — explain the Ranks column
The RESOURCE SHARE "Ranks" column (`C#2 M#3 I— N—`) was cryptic. Added an inline legend: **C=CPU M=Mem I=IO N=Net · #n = rank in that dimension (#1 = top) · — = not ranked**.

## Verification
`CGO_ENABLED=0 go build ./...` clean, `go vet ./...` clean, `go test ./...` → 896 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
