### PR TITLE
feat(apps): Docker/native runtime column + honest warm-up conns

### DIFF
--- a/collector/apps/manager.go
+++ b/collector/apps/manager.go
@@ -215,6 +215,7 @@ func (m *Manager) Collect(snap *model.Snapshot) error {
 					Port:        entry.app.Port,
 					Status:      "active",
 					HealthScore: 100,
+					DeepPending: true, // conns/version not measured in the lite path
 					RSSMB:       readProcRSS(entry.app.PID),
 					Threads:     readProcThreads(entry.app.PID),
 					FDs:         readProcFDs(entry.app.PID),
@@ -230,6 +231,8 @@ func (m *Manager) Collect(snap *model.Snapshot) error {
 			if inst.ID == "" {
 				inst.ID = fmt.Sprintf("%s-%d", entry.module.Type(), entry.app.Index)
 			}
+			// Where does it run: docker / native / k8s / … (cheap cgroup read).
+			inst.Runtime = detectRuntime(entry.app.PID)
 			// Compute delta-based CPU% (real-time, not lifetime average)
 			curTicks := readProcCPUTicks(entry.app.PID)
 			if entry.prevTicks > 0 && curTicks >= entry.prevTicks {

--- a/collector/apps/prochelpers.go
+++ b/collector/apps/prochelpers.go
@@ -57,6 +57,36 @@ func cachedBtime() float64 {
 
 // countTCPConnections counts established TCP connections to a given local port.
 // Parses /proc/net/tcp (and tcp6) looking for connections in ESTABLISHED state (0A=LISTEN, 01=ESTABLISHED).
+// detectRuntime returns where a PID runs — "docker", "containerd", "podman",
+// "k8s", "lxc", or "native" — by inspecting its cgroup. Cheap (one read);
+// returns "native" if the cgroup can't be read.
+func detectRuntime(pid int) string {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+	if err != nil {
+		return "native"
+	}
+	return runtimeFromCgroup(string(data))
+}
+
+// runtimeFromCgroup classifies a cgroup file's contents. Ordered most-specific
+// first: kubepods (k8s) wins over the container runtime beneath it.
+func runtimeFromCgroup(content string) string {
+	switch {
+	case strings.Contains(content, "kubepods"):
+		return "k8s"
+	case strings.Contains(content, "docker"):
+		return "docker"
+	case strings.Contains(content, "containerd"):
+		return "containerd"
+	case strings.Contains(content, "libpod"), strings.Contains(content, "podman"):
+		return "podman"
+	case strings.Contains(content, "/lxc"):
+		return "lxc"
+	default:
+		return "native"
+	}
+}
+
 func countTCPConnections(port int) int {
 	count := 0
 	portHex := fmt.Sprintf("%04X", port)

--- a/collector/apps/runtime_test.go
+++ b/collector/apps/runtime_test.go
@@ -1,0 +1,27 @@
+//go:build linux
+
+package apps
+
+import "testing"
+
+// TestRuntimeFromCgroup verifies container-runtime classification from a PID's
+// cgroup contents — so the apps table can show "docker" vs "native".
+func TestRuntimeFromCgroup(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"docker scope", "0::/system.slice/docker-abc123.scope\n", "docker"},
+		{"docker legacy", "12:pids:/docker/abc123\n", "docker"},
+		{"k8s pod", "0::/kubepods/besteffort/pod-x/abc\n", "k8s"},
+		{"k8s beats containerd", "0::/kubepods/pod-x/cri-containerd-abc.scope\n", "k8s"},
+		{"standalone containerd", "0::/system.slice/containerd.service/abc\n", "containerd"},
+		{"podman libpod", "0::/machine.slice/libpod-abc.scope\n", "podman"},
+		{"native service", "0::/system.slice/postgresql.service\n", "native"},
+		{"empty", "", "native"},
+	}
+	for _, tc := range cases {
+		if got := runtimeFromCgroup(tc.in); got != tc.want {
+			t.Errorf("%s: runtimeFromCgroup(%q) = %q, want %q", tc.name, tc.in, got, tc.want)
+		}
+	}
+}

--- a/model/apps.go
+++ b/model/apps.go
@@ -30,6 +30,15 @@ type AppInstance struct {
 	HealthScore  int      `json:"health_score"`
 	HealthIssues []string `json:"health_issues,omitempty"`
 
+	// Runtime is where the app runs: "docker", "containerd", "podman", "k8s",
+	// "lxc", or "native" (bare host process). Derived from the PID's cgroup.
+	Runtime string `json:"runtime,omitempty"`
+
+	// DeepPending is true for a tier-1-lite instance (first tick or guardian
+	// throttling deep probes): version and connection count were NOT measured
+	// yet, so consumers must render them as "—", not a misleading 0.
+	DeepPending bool `json:"deep_pending,omitempty"`
+
 	// Config
 	ConfigPath string `json:"config_path,omitempty"`
 	NeedsCreds bool   `json:"needs_creds"`

--- a/ui/page_apps.go
+++ b/ui/page_apps.go
@@ -70,10 +70,12 @@ func renderAppsPage(snap *model.Snapshot, result *model.AnalysisResult, selected
 	colConn := 7
 	colThr := 9
 	colHlth := 8
+	colRun := 11
 
-	header := fmt.Sprintf("  %s %s %s %s %s %s %s %s %s",
+	header := fmt.Sprintf("  %s %s %s %s %s %s %s %s %s %s",
 		styledPad(dimStyle.Render("#"), colNum),
 		styledPad(dimStyle.Render("App"), colApp),
+		styledPad(dimStyle.Render("Runtime"), colRun),
 		styledPad(dimStyle.Render("PID"), colPID),
 		styledPad(dimStyle.Render("Port"), colPort),
 		styledPad(dimStyle.Render("RSS"), colRSS),
@@ -105,13 +107,31 @@ func renderAppsPage(snap *model.Snapshot, result *model.AnalysisResult, selected
 			verStr = "—"
 		}
 
-		row := fmt.Sprintf("  %s %s %s %s %s %s %s %s %s",
+		// Runtime: dim "native", highlight containerised.
+		runStr := app.Runtime
+		if runStr == "" {
+			runStr = "—"
+		}
+		runStyled := valueStyle.Render(runStr)
+		if runStr == "native" || runStr == "—" {
+			runStyled = dimStyle.Render(runStr)
+		}
+
+		// Conns: "—" while deep collection is pending (guardian/first tick) — the
+		// count wasn't measured yet, so don't show a misleading 0.
+		connStr := fmt.Sprintf("%d", app.Connections)
+		if app.DeepPending {
+			connStr = "—"
+		}
+
+		row := fmt.Sprintf("  %s %s %s %s %s %s %s %s %s %s",
 			styledPad(dimStyle.Render(fmt.Sprintf("%d", i+1)), colNum),
 			styledPad(valueStyle.Render(name), colApp),
+			styledPad(runStyled, colRun),
 			styledPad(valueStyle.Render(fmt.Sprintf("%d", app.PID)), colPID),
 			styledPad(valueStyle.Render(portStr), colPort),
 			styledPad(valueStyle.Render(rssStr), colRSS),
-			styledPad(valueStyle.Render(fmt.Sprintf("%d", app.Connections)), colConn),
+			styledPad(valueStyle.Render(connStr), colConn),
 			styledPad(valueStyle.Render(fmt.Sprintf("%d", app.Threads)), colThr),
 			styledPad(healthStr, colHlth),
 			dimStyle.Render(verStr))


### PR DESCRIPTION
## Summary
Two Apps-page fixes from live review on a multi-tenant host:

**1. Runtime column (Docker vs native)** — the table never showed whether an app runs in a container or on the bare host. Adds `AppInstance.Runtime` (`docker`/`containerd`/`podman`/`k8s`/`lxc`/`native`), derived from the PID's cgroup via `detectRuntime`/`runtimeFromCgroup` (pure + unit-tested), set centrally in the apps manager. New **Runtime** column ("native" dimmed, containerised highlighted).

**2. Honest warm-up Conns** — on the first tick / when the Resource Guardian throttles deep probes, the manager builds a tier-1-lite instance that deliberately skips `countTCPConnections` and version, so `Conns` showed a misleading **`0`** (really "not measured"). Adds `AppInstance.DeepPending`; the table now shows **`—`** while pending and the real count once measured. Verified: once measured, postgres conns match `/proc` exactly (e.g. 27), redis 5.

## Verification
Build clean, vet clean, full suite passes; `runtimeFromCgroup` unit-tested (docker/k8s/containerd/podman/native/empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Runtime column to the Apps table, showing detected execution environments.
  * Apps with pending deep metrics now display a placeholder instead of potentially misleading connection counts.
  * Added support for indicating when deep metrics are still being collected.

* **Bug Fixes**
  * Improved runtime classification across Kubernetes, Docker, containerd, Podman, LXC, and native environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->