### PR TITLE
fix: verification-sweep findings (LVM IO double-count, partial-scan honesty, Share tree RSS)

### DIFF
--- a/collector/bigfiles.go
+++ b/collector/bigfiles.go
@@ -21,8 +21,9 @@ type BigFileCollector struct {
 	MinSize   uint64 // minimum file size in bytes (default 50MB)
 
 	mu        sync.Mutex
-	cache     []model.BigFile
-	cacheDirs []model.BigDir
+	cache        []model.BigFile
+	cacheDirs    []model.BigDir
+	cachePartial bool
 	lastScan  time.Time
 	triggered bool // set externally when disk pressure detected
 	firstRun  bool // true = skip expensive scan on first tick; set false after first Collect
@@ -68,6 +69,7 @@ func (b *BigFileCollector) Collect(snap *model.Snapshot) error {
 	// Skip expensive full-directory walk on first tick
 	if b.firstRun {
 		b.firstRun = false
+		snap.Global.BigDirsPartial = b.cachePartial
 		b.mu.Unlock()
 		snap.Global.BigFiles = b.cache
 		snap.Global.BigDirs = b.cacheDirs
@@ -80,6 +82,7 @@ func (b *BigFileCollector) Collect(snap *model.Snapshot) error {
 		b.mu.Lock()
 		snap.Global.BigFiles = b.cache
 		snap.Global.BigDirs = b.cacheDirs
+		snap.Global.BigDirsPartial = b.cachePartial
 		b.mu.Unlock()
 		return nil
 	}
@@ -115,16 +118,21 @@ func (b *BigFileCollector) Collect(snap *model.Snapshot) error {
 
 	// Roll the per-directory totals up into the top disjoint subtrees.
 	bigDirs := topDirs(dirs, minSize, maxFiles)
+	// Budget exhausted mid-walk → the directory totals are lower bounds, not
+	// authoritative du output. Surface that so the UI can say so.
+	partial := budget <= 0
 
 	// Update cache
 	b.mu.Lock()
 	b.cache = files
 	b.cacheDirs = bigDirs
+	b.cachePartial = partial
 	b.lastScan = time.Now()
 	b.mu.Unlock()
 
 	snap.Global.BigFiles = files
 	snap.Global.BigDirs = bigDirs
+	snap.Global.BigDirsPartial = partial
 	return nil
 }
 

--- a/collector/bigfiles_test.go
+++ b/collector/bigfiles_test.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -91,5 +92,22 @@ func TestTopDirsRespectsMax(t *testing.T) {
 	}
 	if out[0].SizeBytes != 500 || out[1].SizeBytes != 400 {
 		t.Errorf("expected largest two by size, got %+v", out)
+	}
+}
+
+// TestWalkDirBudgetExhaustionSignals verifies the walk reports budget
+// exhaustion so callers can mark results as a partial (lower-bound) scan
+// instead of presenting truncated sizes as authoritative du output.
+func TestWalkDirBudgetExhaustionSignals(t *testing.T) {
+	root := t.TempDir()
+	for i := 0; i < 5; i++ {
+		writeFile(t, filepath.Join(root, "d", fmt.Sprintf("f%d", i)), 10)
+	}
+
+	var files []model.BigFile
+	dirs := make(map[string]*dirAgg)
+	budget, _, _ := walkDir(root, 0, &files, dirs, 2, 0)
+	if budget > 0 {
+		t.Fatalf("expected budget exhausted (<=0), got %d", budget)
 	}
 }

--- a/collector/cgroup/v2.go
+++ b/collector/cgroup/v2.go
@@ -1,8 +1,10 @@
 package cgroup
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/ftahirops/xtop/model"
 	"github.com/ftahirops/xtop/util"
@@ -78,9 +80,23 @@ func readV2IO(path string, cg *model.CgroupMetrics) {
 	if err != nil {
 		return
 	}
+	sumV2IOLines(lines, isLayeredMajMin, cg)
+}
+
+// sumV2IOLines accumulates io.stat rows into cg, skipping layered
+// (device-mapper) rows: on LVM hosts io.stat reports the SAME bytes at both
+// the dm row (252:0) and the physical row (8:0), so summing all rows doubled
+// every cgroup's IO and the Top-writer attribution built on it.
+func sumV2IOLines(lines []string, isLayered func(majmin string) bool, cg *model.CgroupMetrics) {
 	for _, line := range lines {
 		fields := strings.Fields(line)
-		for _, f := range fields {
+		if len(fields) == 0 {
+			continue
+		}
+		if isLayered(fields[0]) {
+			continue
+		}
+		for _, f := range fields[1:] {
 			parts := strings.SplitN(f, "=", 2)
 			if len(parts) != 2 {
 				continue
@@ -98,4 +114,27 @@ func readV2IO(path string, cg *model.CgroupMetrics) {
 			}
 		}
 	}
+}
+
+// layeredMajMin caches whether a MAJ:MIN is a device-mapper device
+// (has /sys/dev/block/MAJ:MIN/dm). Device numbers are stable for the
+// life of the host, so a grow-only cache is safe.
+var (
+	layeredMu    sync.Mutex
+	layeredCache = map[string]bool{}
+)
+
+func isLayeredMajMin(majmin string) bool {
+	layeredMu.Lock()
+	v, ok := layeredCache[majmin]
+	layeredMu.Unlock()
+	if ok {
+		return v
+	}
+	_, err := os.Stat("/sys/dev/block/" + majmin + "/dm")
+	layered := err == nil
+	layeredMu.Lock()
+	layeredCache[majmin] = layered
+	layeredMu.Unlock()
+	return layered
 }

--- a/collector/cgroup/v2_io_test.go
+++ b/collector/cgroup/v2_io_test.go
@@ -1,0 +1,43 @@
+//go:build linux
+
+package cgroup
+
+import (
+	"testing"
+
+	"github.com/ftahirops/xtop/model"
+)
+
+// On LVM hosts cgroup io.stat lists the SAME bytes at both the device-mapper
+// row (e.g. 252:0) and the physical row (8:0). Summing all rows doubled every
+// cgroup's IO (and the Top-writer attribution built on it). Layered rows must
+// be skipped when identified.
+func TestSumV2IOSkipsDeviceMapperRows(t *testing.T) {
+	lines := []string{
+		"8:0 rbytes=1048576 wbytes=8388608 rios=10 wios=2086 dbytes=0 dios=0",
+		"252:0 rbytes=1048576 wbytes=8388608 rios=10 wios=2126 dbytes=0 dios=0",
+	}
+	isLayered := func(majmin string) bool { return majmin == "252:0" }
+
+	var cg model.CgroupMetrics
+	sumV2IOLines(lines, isLayered, &cg)
+
+	if cg.IORBytes != 1048576 || cg.IOWBytes != 8388608 {
+		t.Fatalf("dm row double-counted: R=%d W=%d, want R=1048576 W=8388608", cg.IORBytes, cg.IOWBytes)
+	}
+	if cg.IOWIOs != 2086 {
+		t.Fatalf("dm row IOs double-counted: wios=%d, want 2086", cg.IOWIOs)
+	}
+}
+
+func TestSumV2IOKeepsAllWhenNoneLayered(t *testing.T) {
+	lines := []string{
+		"8:0 rbytes=100 wbytes=200 rios=1 wios=2",
+		"8:16 rbytes=300 wbytes=400 rios=3 wios=4",
+	}
+	var cg model.CgroupMetrics
+	sumV2IOLines(lines, func(string) bool { return false }, &cg)
+	if cg.IORBytes != 400 || cg.IOWBytes != 600 {
+		t.Fatalf("independent disks must both count: R=%d W=%d", cg.IORBytes, cg.IOWBytes)
+	}
+}

--- a/engine/apps_share.go
+++ b/engine/apps_share.go
@@ -81,8 +81,13 @@ func EnrichAppResourceShare(snap *model.Snapshot, rates *model.RateSnapshot, res
 		if s.CPUCoresUsed == 0 && a.CPUPct > 0 {
 			s.CPUCoresUsed = a.CPUPct / 100.0
 		}
-		if s.MemRSSBytes == 0 && a.RSSMB > 0 {
-			s.MemRSSBytes = uint64(a.RSSMB * 1024 * 1024)
+		// ProcessRates is a top-N SAMPLE: multi-worker apps (postgres backends,
+		// nginx workers) have most of their tree missing from it, which
+		// undercounted Share memory up to 7x while the RSS column on the same
+		// page showed the module's full-tree number. The module's RSSMB is the
+		// authoritative tree measurement — never report less than it.
+		if treeRSS := uint64(a.RSSMB * 1024 * 1024); treeRSS > s.MemRSSBytes {
+			s.MemRSSBytes = treeRSS
 		}
 		s.NetConns = a.Connections
 

--- a/engine/apps_share_test.go
+++ b/engine/apps_share_test.go
@@ -187,3 +187,33 @@ func TestRankApps_ZeroValuesUnranked(t *testing.T) {
 		t.Errorf("idle app rank = %d, want 0 (unranked)", apps[1].Share.RankCPU)
 	}
 }
+
+// TestEnrichAppResourceShare_TreeRSSBeatsSampledSum reproduces the Share memory
+// undercount: ProcessRates is a top-N sample, so a multi-worker app (postgres
+// backends, nginx workers) has most of its tree missing from the sample. The
+// app module already measured the FULL tree RSS (AppInstance.RSSMB); the Share
+// must not report less memory than that. Live case: PG tree = 2094MB but Share
+// showed 298MB (only the sampled PIDs).
+func TestEnrichAppResourceShare_TreeRSSBeatsSampledSum(t *testing.T) {
+	snap, rates := synthScene(
+		4,
+		16*1024*1024*1024,
+		[]model.AppInstance{
+			{ID: "pg", AppType: "postgresql", DisplayName: "PostgreSQL", PID: 100,
+				RSSMB: 2094}, // module-measured full tree RSS
+		},
+		[]model.ProcessRate{
+			// Only the postmaster made the top-N sample; backends missing.
+			{PID: 100, CPUPct: 10, RSS: 298 * 1024 * 1024},
+		},
+		50,
+	)
+
+	EnrichAppResourceShare(snap, rates, nil, nil)
+
+	got := snap.Global.Apps.Instances[0].Share.MemRSSBytes
+	want := uint64(2094) * 1024 * 1024
+	if got < want {
+		t.Fatalf("Share.MemRSSBytes=%d undercounts the measured tree RSS %d", got, want)
+	}
+}

--- a/model/diskrate_sum.go
+++ b/model/diskrate_sum.go
@@ -1,0 +1,45 @@
+package model
+
+import "strings"
+
+// isLayeredBlockDevice reports whether a block device is a virtual layer
+// (device-mapper / md-raid) that re-reports IO already counted at the physical
+// device beneath it in /proc/diskstats.
+func isLayeredBlockDevice(name string) bool {
+	return strings.HasPrefix(name, "dm-") || strings.HasPrefix(name, "md")
+}
+
+// sumDiskRates sums pick() across DiskRates counting each byte once: layered
+// devices (dm-*/md*) are excluded when at least one physical device is present,
+// since LVM/RAID hosts report the same IO at both layers. When only layered
+// devices are visible (e.g. restricted views), they are summed as-is.
+func sumDiskRates(disks []DiskRate, pick func(*DiskRate) (float64, float64)) (a, b float64) {
+	hasPhysical := false
+	for i := range disks {
+		if !isLayeredBlockDevice(disks[i].Name) {
+			hasPhysical = true
+			break
+		}
+	}
+	for i := range disks {
+		if hasPhysical && isLayeredBlockDevice(disks[i].Name) {
+			continue
+		}
+		x, y := pick(&disks[i])
+		a += x
+		b += y
+	}
+	return a, b
+}
+
+// SumDiskThroughput returns host-total read/write MB/s without double-counting
+// LVM/RAID layers.
+func SumDiskThroughput(disks []DiskRate) (readMBs, writeMBs float64) {
+	return sumDiskRates(disks, func(d *DiskRate) (float64, float64) { return d.ReadMBs, d.WriteMBs })
+}
+
+// SumDiskIOPS returns host-total read/write IOPS without double-counting
+// LVM/RAID layers.
+func SumDiskIOPS(disks []DiskRate) (readIOPS, writeIOPS float64) {
+	return sumDiskRates(disks, func(d *DiskRate) (float64, float64) { return d.ReadIOPS, d.WriteIOPS })
+}

--- a/model/diskrate_sum_test.go
+++ b/model/diskrate_sum_test.go
@@ -1,0 +1,45 @@
+package model
+
+import "testing"
+
+// On LVM/dm hosts /proc/diskstats reports the SAME bytes at both the physical
+// layer (sda) and the device-mapper layer (dm-0). Host-total sums must count
+// each byte once: exclude dm-*/md* layers when a physical device is present,
+// but fall back to summing everything when only virtual devices are visible.
+func TestSumDiskThroughputExcludesDMLayer(t *testing.T) {
+	disks := []DiskRate{
+		{Name: "sda", ReadMBs: 1.5, WriteMBs: 8.3, ReadIOPS: 10, WriteIOPS: 2086},
+		{Name: "dm-0", ReadMBs: 1.5, WriteMBs: 8.3, ReadIOPS: 10, WriteIOPS: 2126},
+	}
+	r, w := SumDiskThroughput(disks)
+	if r != 1.5 || w != 8.3 {
+		t.Fatalf("dm layer double-counted: got R=%.1f W=%.1f, want R=1.5 W=8.3", r, w)
+	}
+	ri, wi := SumDiskIOPS(disks)
+	if ri != 10 || wi != 2086 {
+		t.Fatalf("dm layer IOPS double-counted: got R=%.0f W=%.0f, want R=10 W=2086", ri, wi)
+	}
+}
+
+func TestSumDiskThroughputDMOnlyFallback(t *testing.T) {
+	disks := []DiskRate{
+		{Name: "dm-0", ReadMBs: 2, WriteMBs: 4},
+		{Name: "dm-1", ReadMBs: 1, WriteMBs: 1},
+	}
+	r, w := SumDiskThroughput(disks)
+	if r != 3 || w != 5 {
+		t.Fatalf("dm-only host must sum dm devices: got R=%.0f W=%.0f, want R=3 W=5", r, w)
+	}
+}
+
+func TestSumDiskThroughputMultiplePhysical(t *testing.T) {
+	disks := []DiskRate{
+		{Name: "sda", WriteMBs: 4},
+		{Name: "nvme0n1", WriteMBs: 6},
+		{Name: "md0", WriteMBs: 10}, // raid layer over the two — skip
+	}
+	_, w := SumDiskThroughput(disks)
+	if w != 10 {
+		t.Fatalf("got W=%.0f, want 10 (sda+nvme, md layer excluded)", w)
+	}
+}

--- a/model/metrics.go
+++ b/model/metrics.go
@@ -907,6 +907,7 @@ type GlobalMetrics struct {
 	DeletedOpen    []DeletedOpenFile
 	BigFiles       []BigFile
 	BigDirs        []BigDir
+	BigDirsPartial bool // scan stat-budget exhausted: BigDirs sizes are lower bounds
 	FilelessProcs  []FilelessProcess
 	Security       SecurityMetrics
 	Logs           LogMetrics

--- a/ui/layout_f.go
+++ b/ui/layout_f.go
@@ -230,9 +230,9 @@ func renderBtopIOCell(rates *model.RateSnapshot, cellW int) string {
 	var totalRead, totalWrite float64
 
 	if rates != nil {
+		// Totals via SumDiskThroughput so dm/md layers aren't double-counted.
+		totalRead, totalWrite = model.SumDiskThroughput(rates.DiskRates)
 		for _, d := range rates.DiskRates {
-			totalRead += d.ReadMBs
-			totalWrite += d.WriteMBs
 			if d.UtilPct > worstUtil {
 				worstUtil = d.UtilPct
 				worstAwait = d.AvgAwaitMs

--- a/ui/overview.go
+++ b/ui/overview.go
@@ -333,26 +333,18 @@ func extractSubsystems(snap *model.Snapshot, rates *model.RateSnapshot, result *
 		{"Queue depth", qdVal},
 	}
 
-	// Read/write throughput
+	// Read/write throughput + IOPS. SumDisk* count each byte once — on LVM/RAID
+	// hosts /proc/diskstats reports the same IO at both the dm/md layer and the
+	// physical device, and a naive sum doubled every number here.
 	readMBs := float64(0)
 	writeMBs := float64(0)
-	if rates != nil {
-		for _, d := range rates.DiskRates {
-			readMBs += d.ReadMBs
-			writeMBs += d.WriteMBs
-		}
-	}
-	io.Details = append(io.Details, kv{"Throughput", fmt.Sprintf("R:%.1f W:%.1f MB/s", readMBs, writeMBs)})
-
-	// IOPS
 	readIOPS := float64(0)
 	writeIOPS := float64(0)
 	if rates != nil {
-		for _, d := range rates.DiskRates {
-			readIOPS += d.ReadIOPS
-			writeIOPS += d.WriteIOPS
-		}
+		readMBs, writeMBs = model.SumDiskThroughput(rates.DiskRates)
+		readIOPS, writeIOPS = model.SumDiskIOPS(rates.DiskRates)
 	}
+	io.Details = append(io.Details, kv{"Throughput", fmt.Sprintf("R:%.1f W:%.1f MB/s", readMBs, writeMBs)})
 	io.Details = append(io.Details, kv{"IOPS", fmt.Sprintf("R:%.0f W:%.0f", readIOPS, writeIOPS)})
 
 	if result != nil && len(result.IOOwners) > 0 {

--- a/ui/overview_blocks.go
+++ b/ui/overview_blocks.go
@@ -96,14 +96,16 @@ func renderTrendBlock(result *model.AnalysisResult, history *engine.History, wid
 		swapIO[i] = r.SwapInRate + r.SwapOutRate
 		reclaim[i] = r.DirectReclaimRate
 
-		// Worst disk util/await/throughput
+		// Worst disk util/await + total throughput (SumDiskThroughput counts
+		// each byte once — dm/md layers re-report the physical device's IO).
 		for _, d := range r.DiskRates {
 			if d.UtilPct > ioUtil[i] {
 				ioUtil[i] = d.UtilPct
 				ioAwait[i] = d.AvgAwaitMs
 			}
-			ioThru[i] += d.ReadMBs + d.WriteMBs
 		}
+		thruR, thruW := model.SumDiskThroughput(r.DiskRates)
+		ioThru[i] = thruR + thruW
 
 		// Network aggregates
 		for _, nr := range r.NetRates {

--- a/ui/page_diskguard.go
+++ b/ui/page_diskguard.go
@@ -308,6 +308,9 @@ func renderDiskGuardPage(snap *model.Snapshot, rates *model.RateSnapshot, result
 		dimStyle.Render("DIRECTORY"))
 	dirLines = append(dirLines, dirHdr)
 
+	// When the scan's stat budget was exhausted mid-walk the sizes are lower
+	// bounds, not full du totals — say so instead of presenting them as exact.
+	dirsPartial := snap != nil && snap.Global.BigDirsPartial
 	if snap != nil && len(snap.Global.BigDirs) > 0 {
 		shown := 0
 		for _, bd := range snap.Global.BigDirs {
@@ -315,6 +318,9 @@ func renderDiskGuardPage(snap *model.Snapshot, rates *model.RateSnapshot, result
 				break
 			}
 			sizeStr := fmtBytes(bd.SizeBytes)
+			if dirsPartial {
+				sizeStr = "≥" + sizeStr
+			}
 			if bd.SizeBytes > 1024*1024*1024 {
 				sizeStr = critStyle.Render(sizeStr)
 			} else if bd.SizeBytes > 100*1024*1024 {
@@ -331,7 +337,11 @@ func renderDiskGuardPage(snap *model.Snapshot, rates *model.RateSnapshot, result
 	} else {
 		dirLines = append(dirLines, dimStyle.Render("  no directories > 50MB in scanned paths"))
 	}
-	sb.WriteString(boxSection("TOP DIRECTORIES", dirLines, iw))
+	dirTitle := "TOP DIRECTORIES"
+	if dirsPartial {
+		dirTitle = "TOP DIRECTORIES (partial scan — sizes are at-least)"
+	}
+	sb.WriteString(boxSection(dirTitle, dirLines, iw))
 
 	// Section 4: DELETED-BUT-OPEN FILES
 	var delLines []string


### PR DESCRIPTION
## Summary
A full per-page parameter verification (22-page multi-agent sweep vs live /proc, ss, df, du ground truth) found 3 real reporting bugs. Each was reproduced as a failing test first:

1. **Overview Disk IO doubled on LVM/RAID hosts** — /proc/diskstats reports the same bytes at the dm/md layer AND the physical device; the card summed all DiskRates (showed W:16.7 MB/s vs 8.3 physical, IOPS 4212 vs ~2086). New `model.SumDiskThroughput/SumDiskIOPS` count each byte once; cgroup `io.stat` parsing (Top-writer attribution) had the same doubling — dm rows now skipped via `/sys/dev/block/MAJ:MIN/dm`.
2. **TOP DIRECTORIES presented truncated sizes as authoritative** (708MB shown for a real 1.42GB tree after the 3000-stat budget ran out). New `BigDirsPartial` flag → section shows "(partial scan — sizes are at-least)" and `≥` size prefixes.
3. **Apps RESOURCE SHARE Mem undercounted multi-worker apps up to 7×** (PG tree 2094MB shown as 298MB) — Share aggregated only the top-N ProcessRates sample; it now never reports less than the module's full-tree RSSMB.

A 4th suspect (apps detection empty in one-shot mode) was NOT reproducible (3/3 clean runs = 6 apps) — occurs only under the verifier storm's own load (~20 concurrent xtop instances); classified load-induced transient, not fixed speculatively.

## Verification
Build clean, vet clean, full suite passes. 6 new tests (dm exclusion + fallback + multi-physical, io.stat dm-row skip, budget-exhaustion signal, tree-RSS floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Disk usage totals now avoid double-counting layered devices such as device-mapper and RAID volumes.
  * Disk guard reports when directory scanning is incomplete and marks displayed sizes as minimum values.
  * App memory resource shares now account for full application tree usage when sampled process data is incomplete.

* **Bug Fixes**
  * Improved accuracy for disk throughput, IOPS, and cgroup I/O metrics.
  * Preserved incomplete directory-scan status when cached results are reused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->