### PR TITLE
feat(diskguard): dux live filesystem index — exact sizes + per-path growth

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -140,6 +140,7 @@ func richCollectors() []Collector {
 		&DeletedOpenCollector{MaxFiles: 20},
 		&FilelessCollector{},
 		&BigFileCollector{MaxFiles: 10, MinSize: 50 * 1024 * 1024, firstRun: true},
+		&DuxCollector{}, // dux live-index view (silent no-op when dux absent)
 		&ProcessCollector{MaxProcs: 50},
 		&IdentityCollector{},
 		&SecurityCollector{},

--- a/collector/dux.go
+++ b/collector/dux.go
@@ -1,0 +1,202 @@
+//go:build linux
+
+package collector
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ftahirops/xtop/model"
+)
+
+// DuxCollector reads the dux live filesystem index (https://github.com/ftahirops/dux)
+// when the `dux` CLI is installed. dux maintains a persistent, fanotify-updated
+// SQLite index of the whole filesystem, so it answers "top directories", "top
+// files", and — uniquely — "what grew in the last N minutes" instantly and
+// exactly, where the built-in BigFileCollector walker is budget-bounded and
+// blind to growth. Integration is via `dux ... --json` subprocess calls (3s
+// timeout each): no schema coupling, no extra Go dependencies, and the
+// collector is a silent no-op when dux is absent.
+type DuxCollector struct {
+	mu        sync.Mutex
+	cacheOK   bool
+	cacheDirs []model.BigDir
+	cacheFile []model.BigFile
+	cacheGrow []model.GrowthEntry
+	lastScan  time.Time
+	triggered bool
+	missing   bool      // dux not in PATH — checked once, rechecked hourly
+	checkedAt time.Time // when `missing` was last evaluated
+}
+
+func (d *DuxCollector) Name() string { return "dux" }
+
+// Trigger forces a refresh on the next Collect (wired to disk WARN/CRIT,
+// like the bigfiles collector).
+func (d *DuxCollector) Trigger() {
+	d.mu.Lock()
+	d.triggered = true
+	d.mu.Unlock()
+}
+
+const (
+	duxRefreshInterval = 60 * time.Second
+	duxGrowthWindow    = "15m"
+	duxTopLimit        = "12"
+	duxCmdTimeout      = 3 * time.Second
+)
+
+// duxRow is one entry of `dux top --json` output.
+type duxRow struct {
+	Bytes  uint64 `json:"bytes"`
+	Inodes int    `json:"inodes"`
+	Kind   string `json:"kind"`
+	Mtime  int64  `json:"mtime"`
+	Path   string `json:"path"`
+}
+
+func parseDuxRows(data []byte) ([]duxRow, error) {
+	var rows []duxRow
+	if err := json.Unmarshal(data, &rows); err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// duxDirsFromRows converts top-dirs rows, dropping the root "/" row (it is
+// "everything on the filesystem" — noise in a hot-spots list).
+func duxDirsFromRows(rows []duxRow) []model.BigDir {
+	out := make([]model.BigDir, 0, len(rows))
+	for _, r := range rows {
+		if r.Path == "/" {
+			continue
+		}
+		out = append(out, model.BigDir{
+			Path:      r.Path,
+			SizeBytes: r.Bytes,
+			FileCount: r.Inodes,
+		})
+	}
+	return out
+}
+
+func duxFilesFromRows(rows []duxRow) []model.BigFile {
+	out := make([]model.BigFile, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, model.BigFile{
+			Path:      r.Path,
+			SizeBytes: r.Bytes,
+			ModTime:   r.Mtime,
+		})
+	}
+	return out
+}
+
+// parseDuxGrowth parses `dux growth --json`, dropping "inode:NNN" rows —
+// entries whose path the index could not resolve (nothing actionable to show).
+func parseDuxGrowth(data []byte) ([]model.GrowthEntry, error) {
+	var raw []struct {
+		DeltaBytes int64  `json:"delta_bytes"`
+		Path       string `json:"path"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	out := make([]model.GrowthEntry, 0, len(raw))
+	for _, r := range raw {
+		if strings.HasPrefix(r.Path, "inode:") {
+			continue
+		}
+		out = append(out, model.GrowthEntry{Path: r.Path, DeltaBytes: r.DeltaBytes})
+	}
+	return out, nil
+}
+
+func runDux(args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), duxCmdTimeout)
+	defer cancel()
+	return exec.CommandContext(ctx, "dux", args...).Output()
+}
+
+func (d *DuxCollector) Collect(snap *model.Snapshot) error {
+	d.mu.Lock()
+	// Availability: LookPath once, re-check hourly (dux may get installed later).
+	if d.checkedAt.IsZero() || time.Since(d.checkedAt) > time.Hour {
+		_, err := exec.LookPath("dux")
+		d.missing = err != nil
+		d.checkedAt = time.Now()
+	}
+	if d.missing {
+		d.mu.Unlock()
+		return nil // silent no-op: the built-in walker remains the source
+	}
+	needScan := d.triggered || time.Since(d.lastScan) >= duxRefreshInterval
+	d.triggered = false
+	if !needScan {
+		snap.Global.DuxOK = d.cacheOK
+		snap.Global.DuxDirs = d.cacheDirs
+		snap.Global.DuxFiles = d.cacheFile
+		snap.Global.DuxGrowth = d.cacheGrow
+		d.mu.Unlock()
+		return nil
+	}
+	d.mu.Unlock()
+
+	var (
+		dirs   []model.BigDir
+		files  []model.BigFile
+		growth []model.GrowthEntry
+		ok     = true
+	)
+	if out, err := runDux("top", "--dirs", "--limit", duxTopLimit, "--json"); err == nil {
+		if rows, perr := parseDuxRows(out); perr == nil {
+			dirs = duxDirsFromRows(rows)
+		} else {
+			ok = false
+		}
+	} else {
+		ok = false
+	}
+	if out, err := runDux("top", "--files", "--limit", duxTopLimit, "--json"); err == nil {
+		if rows, perr := parseDuxRows(out); perr == nil {
+			files = duxFilesFromRows(rows)
+		} else {
+			ok = false
+		}
+	} else {
+		ok = false
+	}
+	if out, err := runDux("growth", "--since", duxGrowthWindow, "--limit", duxTopLimit, "--json"); err == nil {
+		if g, perr := parseDuxGrowth(out); perr == nil {
+			growth = g
+		}
+		// growth failing alone doesn't invalidate the top data
+	}
+	// A run with no usable data at all → not OK (e.g. index missing/corrupt);
+	// the UI then falls back to the built-in walker sections.
+	if len(dirs) == 0 && len(files) == 0 {
+		ok = false
+	}
+
+	d.mu.Lock()
+	d.cacheOK = ok
+	d.cacheDirs = dirs
+	d.cacheFile = files
+	d.cacheGrow = growth
+	d.lastScan = time.Now()
+	d.mu.Unlock()
+
+	snap.Global.DuxOK = ok
+	snap.Global.DuxDirs = dirs
+	snap.Global.DuxFiles = files
+	snap.Global.DuxGrowth = growth
+	return nil
+}
+
+// MaxMsPerTick declares the cost envelope for the Resource Guardian: three
+// short subprocess calls at most once per minute; the cached path is ~0ms.
+func (d *DuxCollector) MaxMsPerTick() int { return 100 }

--- a/collector/dux_test.go
+++ b/collector/dux_test.go
@@ -1,0 +1,78 @@
+//go:build linux
+
+package collector
+
+import "testing"
+
+// Real `dux top --json` output shape (dux 0.5.2).
+const duxTopJSON = `[
+  {"bytes": 42479112192, "inodes": 347246, "kind": "dir", "mtime": 1782986988, "path": "/home"},
+  {"bytes": 147949282816, "inodes": 1669441, "kind": "dir", "mtime": 1779826740, "path": "/"},
+  {"bytes": 8608407552, "inodes": 1, "kind": "file", "mtime": 1782757577, "path": "/var/lib/xhelix/cold.db"}
+]`
+
+// Real `dux growth --json` output shape. "inode:NNN" rows are entries whose
+// path could not be resolved — useless to display, must be filtered.
+const duxGrowthJSON = `[
+  {"delta_bytes": 68132864, "path": "/tmp/go-build669811604/b001/service.test"},
+  {"delta_bytes": 37281792, "path": "inode:265307"},
+  {"delta_bytes": 21282816, "path": "/var/log/vault/audit.log"}
+]`
+
+func TestParseDuxRows(t *testing.T) {
+	rows, err := parseDuxRows([]byte(duxTopJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3", len(rows))
+	}
+	if rows[0].Path != "/home" || rows[0].Bytes != 42479112192 || rows[0].Inodes != 347246 {
+		t.Fatalf("row 0 mismatch: %+v", rows[0])
+	}
+	if rows[2].Kind != "file" || rows[2].Mtime != 1782757577 {
+		t.Fatalf("row 2 mismatch: %+v", rows[2])
+	}
+}
+
+// The root "/" row is "everything on the filesystem" — noise in a top-dirs
+// list; duxDirsFromRows must drop it and convert the rest.
+func TestDuxDirsFromRowsSkipsRoot(t *testing.T) {
+	rows, err := parseDuxRows([]byte(duxTopJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dirs := duxDirsFromRows(rows)
+	for _, d := range dirs {
+		if d.Path == "/" {
+			t.Fatal("root row must be dropped from top dirs")
+		}
+	}
+	if len(dirs) == 0 || dirs[0].Path != "/home" || dirs[0].SizeBytes != 42479112192 || dirs[0].FileCount != 347246 {
+		t.Fatalf("converted dirs wrong: %+v", dirs)
+	}
+}
+
+func TestParseDuxGrowthFiltersUnresolved(t *testing.T) {
+	entries, err := parseDuxGrowth([]byte(duxGrowthJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2 (inode:NNN row filtered)", len(entries))
+	}
+	if entries[0].Path != "/tmp/go-build669811604/b001/service.test" || entries[0].DeltaBytes != 68132864 {
+		t.Fatalf("entry 0 mismatch: %+v", entries[0])
+	}
+	for _, e := range entries {
+		if len(e.Path) > 6 && e.Path[:6] == "inode:" {
+			t.Fatalf("unresolved inode row leaked: %+v", e)
+		}
+	}
+}
+
+func TestParseDuxRowsBadJSON(t *testing.T) {
+	if _, err := parseDuxRows([]byte("not json")); err == nil {
+		t.Fatal("expected error on malformed input")
+	}
+}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -745,6 +745,7 @@ func (e *Engine) Tick() (*model.Snapshot, *model.RateSnapshot, *model.AnalysisRe
 		if worst == "WARN" || worst == "CRIT" {
 			e.registry.TriggerByName("bigfiles")
 			e.registry.TriggerByName("deleted_open")
+			e.registry.TriggerByName("dux") // fresh growth data for "what's filling the disk"
 		}
 
 		// Push to multi-resolution buffer if enabled

--- a/model/metrics.go
+++ b/model/metrics.go
@@ -210,6 +210,12 @@ type BigDir struct {
 	FileCount int // number of regular files counted in the subtree
 }
 
+// GrowthEntry is one path's recent size change, from the dux live index.
+type GrowthEntry struct {
+	Path       string
+	DeltaBytes int64
+}
+
 // DeletedOpenFile represents a file that was deleted but is still held open.
 type DeletedOpenFile struct {
 	PID       int
@@ -908,6 +914,15 @@ type GlobalMetrics struct {
 	BigFiles       []BigFile
 	BigDirs        []BigDir
 	BigDirsPartial bool // scan stat-budget exhausted: BigDirs sizes are lower bounds
+
+	// Dux live-index view (populated only when the `dux` CLI + its persistent
+	// index are present on the host). Unlike the budget-bounded walker above,
+	// these are exact full-filesystem numbers, and DuxGrowth is per-path recent
+	// growth — something the walker cannot measure at all.
+	DuxOK     bool          // dux available and last query succeeded
+	DuxDirs   []BigDir      // top directories by exact recursive size
+	DuxFiles  []BigFile     // top files by exact size
+	DuxGrowth []GrowthEntry // fastest-growing paths in the recent window
 	FilelessProcs  []FilelessProcess
 	Security       SecurityMetrics
 	Logs           LogMetrics

--- a/ui/page_diskguard.go
+++ b/ui/page_diskguard.go
@@ -267,6 +267,12 @@ func renderDiskGuardPage(snap *model.Snapshot, rates *model.RateSnapshot, result
 
 	sb.WriteString(boxSection("TOP WRITERS", writerLines, iw))
 
+	// Sections 3/3b/3c: biggest files, top directories, recent growth.
+	// Source selection: prefer the dux live index when available (exact
+	// full-filesystem numbers + growth); fall back to the built-in
+	// budget-bounded walker otherwise.
+	useDux := snap != nil && snap.Global.DuxOK
+
 	// Section 3: BIGGEST FILES
 	var bigLines []string
 	bigHdr := fmt.Sprintf("%s %s %s",
@@ -275,9 +281,16 @@ func renderDiskGuardPage(snap *model.Snapshot, rates *model.RateSnapshot, result
 		dimStyle.Render("FILE"))
 	bigLines = append(bigLines, bigHdr)
 
-	if snap != nil && len(snap.Global.BigFiles) > 0 {
+	bigFiles := []model.BigFile(nil)
+	if snap != nil {
+		bigFiles = snap.Global.BigFiles
+		if useDux && len(snap.Global.DuxFiles) > 0 {
+			bigFiles = snap.Global.DuxFiles
+		}
+	}
+	if len(bigFiles) > 0 {
 		shown := 0
-		for _, bf := range snap.Global.BigFiles {
+		for _, bf := range bigFiles {
 			if shown >= 6 {
 				break
 			}
@@ -298,9 +311,13 @@ func renderDiskGuardPage(snap *model.Snapshot, rates *model.RateSnapshot, result
 	} else {
 		bigLines = append(bigLines, dimStyle.Render("  no files > 50MB found"))
 	}
-	sb.WriteString(boxSection("BIGGEST FILES", bigLines, iw))
+	bigTitle := "BIGGEST FILES"
+	if useDux {
+		bigTitle = "BIGGEST FILES (dux index — whole filesystem)"
+	}
+	sb.WriteString(boxSection(bigTitle, bigLines, iw))
 
-	// Section 3b: TOP DIRECTORIES (du-style recursive rollup of the walk)
+	// Section 3b: TOP DIRECTORIES (du-style)
 	var dirLines []string
 	dirHdr := fmt.Sprintf("%s %s %s",
 		styledPad(dimStyle.Render("SIZE"), 10),
@@ -308,12 +325,19 @@ func renderDiskGuardPage(snap *model.Snapshot, rates *model.RateSnapshot, result
 		dimStyle.Render("DIRECTORY"))
 	dirLines = append(dirLines, dirHdr)
 
-	// When the scan's stat budget was exhausted mid-walk the sizes are lower
-	// bounds, not full du totals — say so instead of presenting them as exact.
-	dirsPartial := snap != nil && snap.Global.BigDirsPartial
-	if snap != nil && len(snap.Global.BigDirs) > 0 {
+	// When the walker's stat budget was exhausted mid-walk the sizes are lower
+	// bounds, not full du totals — say so. The dux index has no such limit.
+	dirsPartial := snap != nil && snap.Global.BigDirsPartial && !useDux
+	bigDirs := []model.BigDir(nil)
+	if snap != nil {
+		bigDirs = snap.Global.BigDirs
+		if useDux && len(snap.Global.DuxDirs) > 0 {
+			bigDirs = snap.Global.DuxDirs
+		}
+	}
+	if len(bigDirs) > 0 {
 		shown := 0
-		for _, bd := range snap.Global.BigDirs {
+		for _, bd := range bigDirs {
 			if shown >= 6 {
 				break
 			}
@@ -338,10 +362,38 @@ func renderDiskGuardPage(snap *model.Snapshot, rates *model.RateSnapshot, result
 		dirLines = append(dirLines, dimStyle.Render("  no directories > 50MB in scanned paths"))
 	}
 	dirTitle := "TOP DIRECTORIES"
-	if dirsPartial {
+	if useDux {
+		dirTitle = "TOP DIRECTORIES (dux index — exact)"
+	} else if dirsPartial {
 		dirTitle = "TOP DIRECTORIES (partial scan — sizes are at-least)"
 	}
 	sb.WriteString(boxSection(dirTitle, dirLines, iw))
+
+	// Section 3c: RECENT GROWTH — per-path growth from the dux live index.
+	// Only rendered when dux is available; the walker cannot measure this.
+	if useDux && len(snap.Global.DuxGrowth) > 0 {
+		var growLines []string
+		growLines = append(growLines, fmt.Sprintf("%s %s",
+			styledPad(dimStyle.Render("GREW BY"), 12),
+			dimStyle.Render("PATH")))
+		shown := 0
+		for _, g := range snap.Global.DuxGrowth {
+			if shown >= 6 || g.DeltaBytes <= 0 {
+				break // sorted descending; stop at shrinking paths
+			}
+			deltaStr := "+" + fmtBytes(uint64(g.DeltaBytes))
+			if g.DeltaBytes > 1024*1024*1024 {
+				deltaStr = critStyle.Render(deltaStr)
+			} else if g.DeltaBytes > 100*1024*1024 {
+				deltaStr = warnStyle.Render(deltaStr)
+			}
+			growLines = append(growLines, fmt.Sprintf("%s %s",
+				styledPad(deltaStr, 12),
+				truncate(g.Path, 90)))
+			shown++
+		}
+		sb.WriteString(boxSection("RECENT GROWTH (last 15m — dux live index)", growLines, iw))
+	}
 
 	// Section 4: DELETED-BUT-OPEN FILES
 	var delLines []string


### PR DESCRIPTION
## Summary
Integrates the **dux** live filesystem index (persistent, fanotify-updated SQLite index) into DiskGuard. When the `dux` CLI is present:

- **BIGGEST FILES / TOP DIRECTORIES** switch from the budget-bounded walker (3000 stats, lower-bound sizes, fixed roots) to the **exact whole-filesystem index** (titled "dux index — exact")
- New **RECENT GROWTH (last 15m)** section — the fastest-growing paths right now, something a point-in-time walker cannot measure at all
- Refresh every 60s + triggered immediately on disk WARN/CRIT (same wiring as bigfiles)

## Design
- Subprocess `dux ... --json` calls (3s timeouts) — **no new Go dependencies, no SQLite schema coupling**; silent no-op fallback to the built-in walker when dux is absent
- Rich mode only; lean fleet agent unaffected
- Parse functions unit-tested against captured dux 0.5.2 JSON (root-row + unresolved-inode filtering, malformed input)

## Live verification (this host, dux daemon running)
`DuxOK=true`, dirs: /home 42GB/347,266 files (exact), growth correctly caught in-flight go-build writes (+90MB /tmp/go-build...).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live filesystem index powered by `dux` on Linux systems.
  * Disk Guard now displays whole-filesystem top directories and largest files when live index data is available.
  * Added a “Recent Growth” section showing paths with the greatest size increases over the last 15 minutes.
  * Live index collection refreshes automatically and can be triggered during disk-pressure conditions.

* **Bug Fixes**
  * Gracefully handles systems where `dux` is unavailable without disrupting other Disk Guard data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->